### PR TITLE
Add action to publish Wheatley to PyPI (take 2)

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,41 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine pytest
+        pip install -r requirements.txt
+        sudo apt-install pylint3
+    - name: Run linter
+      run: pylint3 wheatley/**/*.py
+    - name: Run tests
+      run: python -m pytest
+    - name: Make version file
+      run: |
+        echo ${{ github.ref }} | sed 's:.*/v::' > wheatley/version.txt
+        cat wheatley/version.txt
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*


### PR DESCRIPTION
This runs the unit tests, then the linter, then writes the tag name to `wheatley/version.txt`, then publishes the new version to PyPI.  I've already set up the secrets required.  Requires #43 to be merged before the first release.