### PR TITLE
Add extra arguments

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,6 +1,8 @@
 # 0.2.0
 - Added CLI arg for max rows stored in the regression dataset (`-X` or `--max-rows-in-dataset`)
 - Added CLI arg for handstroke gap (`-G` or `--handstroke-gap`)
+- Renamed shorthand for `--inertia` from `-i` to `-I` for consistency with the other regression
+  args
 
 # 0.1.0
 - Added CLI arg for peal speed (`S` or `--peal-speed`)

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,5 +1,6 @@
 # 0.2.0
 - Added CLI arg for max rows stored in the regression dataset (`-X` or `--max-rows-in-dataset`)
+- Added CLI arg for handstroke gap (`-G` or `--handstroke-gap`)
 
 # 0.1.0
 - Added CLI arg for peal speed (`S` or `--peal-speed`)

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,0 +1,7 @@
+# 0.2.0
+- Added CLI arg for max rows stored in the regression dataset (`-X` or `--max-rows-in-dataset`)
+
+# 0.1.0
+- Added CLI arg for peal speed (`S` or `--peal-speed`)
+- Added `--version` string, which is set automatically by the GitHub Action for releasing to PyPI
+- Renamed the bot to Wheatley

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Run the bot with `wheatley [ARGS]`.
     ```bash
     wheatley [ID NUMBER] --method "Plain Bob Major" --inertia 1.0
     # or
-    wheatley [ID NUMBER] --method "Plain Bob Major" -i 1.0
+    wheatley [ID NUMBER] --method "Plain Bob Major" -I 1.0
     ```
 
 *   Print a nice help string:

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -130,7 +130,11 @@ def rhythm(args):
     except PealSpeedParseError as e:
         sys.exit(str(e))
 
-    regression = RegressionRhythm(args.inertia, peal_speed)
+    regression = RegressionRhythm(
+        args.inertia,
+        peal_speed=peal_speed,
+        max_rows_in_dataset=args.max_rows_in_dataset
+    )
 
     if args.wait:
         return WaitForUserRhythm(regression)
@@ -231,6 +235,16 @@ def main():
               though this will usually be adjusted by the bot whilst ringing to keep with other \
               ringers.  Example formatting: '3h4' = '3h4m' = '3h04m' = '3h04' = '184m' = '184'. \
               Defaults to '2h58'."
+    )
+    parser.add_argument(
+        "-X", "--max-rows-in-dataset",
+        type=float,
+        default=3.0,
+        help="Sets the maximum number of rows that Wheatley will store to determine the current \
+              ringing speed.  If you make this larger, then will be more consistent but less \
+              quick to respond to changes in rhythm.  Defaults to 3.0.  Setting both this and \
+              --inertia to a very small values could result in Wheatley ringing ridiculously \
+              quickly."
     )
 
     # Row generator arguments

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -220,7 +220,7 @@ def main():
         help="If set, the bot will wait for users to ring rather than pushing on with the rhythm."
     )
     parser.add_argument(
-        "-i", "--inertia",
+        "-I", "--inertia",
         type=float,
         default=0.5,
         help="Overrides the bot's 'inertia' - now much the bot will take other ringers' positions \

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -132,6 +132,7 @@ def rhythm(args):
 
     regression = RegressionRhythm(
         args.inertia,
+        handstroke_gap=args.handstroke_gap,
         peal_speed=peal_speed,
         max_rows_in_dataset=args.max_rows_in_dataset
     )
@@ -235,6 +236,13 @@ def main():
               though this will usually be adjusted by the bot whilst ringing to keep with other \
               ringers.  Example formatting: '3h4' = '3h4m' = '3h04m' = '3h04' = '184m' = '184'. \
               Defaults to '2h58'."
+    )
+    parser.add_argument(
+        "-G", "--handstroke-gap",
+        type=float,
+        default=1.0,
+        help="Sets the handstroke gap as a factor of the space between two bells.  Defaults to \
+              '1.0'."
     )
     parser.add_argument(
         "-X", "--max-rows-in-dataset",

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -250,7 +250,7 @@ def main():
         default=3.0,
         help="Sets the maximum number of rows that Wheatley will store to determine the current \
               ringing speed.  If you make this larger, then will be more consistent but less \
-              quick to respond to changes in rhythm.  Defaults to 3.0.  Setting both this and \
+              quick to respond to changes in rhythm.  Defaults to '3.0'.  Setting both this and \
               --inertia to a very small values could result in Wheatley ringing ridiculously \
               quickly."
     )

--- a/wheatley/rhythm.py
+++ b/wheatley/rhythm.py
@@ -141,7 +141,7 @@ class RegressionRhythm(Rhythm):
 
     logger_name = "RHYTHM:Regression"
 
-    def __init__(self, inertia, peal_speed=178, handstroke_gap=1, max_changes_in_dataset=3.0):
+    def __init__(self, inertia, peal_speed=178, handstroke_gap=1, max_rows_in_dataset=3.0):
         """
         Initialises a new RegressionRhythm with a given default peal speed and handstroke gap.
         `peal_speed` is the number of minutes in a peal of 5040 changes, and `handstroke_gap`
@@ -156,7 +156,7 @@ class RegressionRhythm(Rhythm):
 
         self._peal_speed = peal_speed
         self._handstroke_gap = handstroke_gap
-        self._max_changes_in_dataset = max_changes_in_dataset
+        self._max_rows_in_dataset = max_changes_in_dataset
 
         self.stage = 0
         self.logger = logging.getLogger(self.logger_name)
@@ -177,7 +177,7 @@ class RegressionRhythm(Rhythm):
         for (b, r, w) in self.data_set:
             self.logger.debug(f"  {b}\t{r}\t{w}")
 
-        max_dataset_length = self._max_changes_in_dataset * self._number_of_user_controlled_bells
+        max_dataset_length = self._max_rows_in_dataset * self._number_of_user_controlled_bells
 
         # Only calculate the regression line if there are at least two datapoints, otherwise
         # just store the datapoint

--- a/wheatley/rhythm.py
+++ b/wheatley/rhythm.py
@@ -13,7 +13,6 @@ from wheatley.bell import Bell
 from wheatley.regression import calculate_regression
 
 
-MAX_CHANGES_IN_DATASET = 3.0
 WEIGHT_REJECTION_THRESHOLD = 0.001
 
 
@@ -142,7 +141,7 @@ class RegressionRhythm(Rhythm):
 
     logger_name = "RHYTHM:Regression"
 
-    def __init__(self, inertia, peal_speed=178, handstroke_gap=1):
+    def __init__(self, inertia, peal_speed=178, handstroke_gap=1, max_changes_in_dataset=3.0):
         """
         Initialises a new RegressionRhythm with a given default peal speed and handstroke gap.
         `peal_speed` is the number of minutes in a peal of 5040 changes, and `handstroke_gap`
@@ -157,6 +156,7 @@ class RegressionRhythm(Rhythm):
 
         self._peal_speed = peal_speed
         self._handstroke_gap = handstroke_gap
+        self._max_changes_in_dataset = max_changes_in_dataset
 
         self.stage = 0
         self.logger = logging.getLogger(self.logger_name)
@@ -177,7 +177,7 @@ class RegressionRhythm(Rhythm):
         for (b, r, w) in self.data_set:
             self.logger.debug(f"  {b}\t{r}\t{w}")
 
-        max_dataset_length = MAX_CHANGES_IN_DATASET * self._number_of_user_controlled_bells
+        max_dataset_length = self._max_changes_in_dataset * self._number_of_user_controlled_bells
 
         # Only calculate the regression line if there are at least two datapoints, otherwise
         # just store the datapoint

--- a/wheatley/rhythm.py
+++ b/wheatley/rhythm.py
@@ -156,7 +156,7 @@ class RegressionRhythm(Rhythm):
 
         self._peal_speed = peal_speed
         self._handstroke_gap = handstroke_gap
-        self._max_rows_in_dataset = max_changes_in_dataset
+        self._max_rows_in_dataset = max_rows_in_dataset
 
         self.stage = 0
         self.logger = logging.getLogger(self.logger_name)


### PR DESCRIPTION
Add arguments for handstroke gap and the max rows in the regression dataset.

Also added a change log to track changes.

I'm tempted to change the short version of the `--inertia` argument to `-I` rather than `i` to fit with the other regression tuning parameters being capital letters (by the way, I've made them all capital because I don't expect them to be used that much, and so I'm leaving the lower case letters free for more common args).  What do you think about that change?