### PR TITLE
Make better error messages

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,5 +1,14 @@
 # 0.3.0
 - Added overridable bobs and singles (`-b`/`--bob` for Bobs, `-n`/`--single` for Singles)
+- Made the error messages nicer for the following scenaria:
+  - Inputting an method name not found in the CC method library
+  - Inputting the ID of a non-existent CompLib composition
+  - Inputting the ID of a private CompLib composition (since private comps are not supported yet)
+  - Inputting the ID of a tower that doesn't exist
+  - Inputting an invalid ringing room URL
+- Added a warning if you enter a method or comp which is incompatible with the number of bells in
+  the tower
+- The `--url` parameter will now automatically add `https://` or remove page paths if needed
 
 # 0.2.0
 - Added CLI arg for max rows stored in the regression dataset (`-X` or `--max-rows-in-dataset`)

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,6 +1,6 @@
 # 0.3.0
 - Added overridable bobs and singles (`-b`/`--bob` for Bobs, `-n`/`--single` for Singles)
-- Made the error messages nicer for the following scenaria:
+- Made the error messages less cryptic for the following scenaria:
   - Inputting an method name not found in the CC method library
   - Inputting the ID of a non-existent CompLib composition
   - Inputting the ID of a private CompLib composition (since private comps are not supported yet)

--- a/fuzz
+++ b/fuzz
@@ -3,4 +3,4 @@
 """ A script to run all the fuzzing tests. """
 
 # Run the fuzzing tests
-from fuzzing import call_parsing
+from fuzzing import call_parsing, peal_speed_parsing

--- a/fuzzing/peal_speed_parsing.py
+++ b/fuzzing/peal_speed_parsing.py
@@ -1,0 +1,19 @@
+""" Run a fuzzer to generate lots of random input for the peal speed parser. """
+
+from random import choice, randint
+
+from wheatley.arg_parsing import parse_peal_speed, PealSpeedParseError
+
+from .fuzz_utils import fuzz_for_unwrapped_errors
+
+def random_peal_speed_string():
+    """ Generate a plausable input value for `wheatley.arg_parsing.parse_peal_speed` to parse. """
+
+    return "".join([choice("1234567890hm,\nx?ET ") for _ in range(randint(0, 20))])
+
+fuzz_for_unwrapped_errors(
+    "parse_peal_speed",
+    parse_peal_speed,
+    random_peal_speed_string,
+    PealSpeedParseError
+)

--- a/wheatley/bot.py
+++ b/wheatley/bot.py
@@ -5,6 +5,7 @@ program.
 """
 
 import time
+import logging
 
 from wheatley import calls
 from wheatley.row_generation import RowGenerator
@@ -18,6 +19,8 @@ class Bot:
     A class to hold all the information that the bot will use to glue together the rhythm,
     row_gen and socket-io parts together into a useful program.
     """
+
+    logger_name = "BOT"
 
     def __init__(self, tower: RingingRoomTower, row_generator: RowGenerator, do_up_down_in,
                  stop_at_rounds, rhythm: Rhythm):
@@ -54,6 +57,8 @@ class Bot:
 
         self._row = None
 
+        self.logger = logging.getLogger(self.logger_name)
+
     # Convenient properties that are frequently used
     @property
     def is_handstroke(self):
@@ -72,8 +77,9 @@ class Bot:
     # Callbacks
     def _on_size_change(self):
         if not self.row_generator.is_tower_size_valid(self._tower.number_of_bells):
-            print("WARNING: Row generation stage is NOT consistent with tower size! \
-Wheatley will crash when you go into changes unless something is done")
+            self.logger.warning("Row generation requires {self.row_generator.number_of_bells} \
+bells, but the current tower has {self._tower.number_of_bells}.  Wheatley will crash when you go \
+into changes unless something is done!")
 
     def _on_look_to(self):
         """ Callback called when a user calls 'Look To'. """

--- a/wheatley/bot.py
+++ b/wheatley/bot.py
@@ -40,6 +40,7 @@ class Bot:
         self._tower.invoke_on_call[calls.STAND].append(self._on_stand_next)
 
         self._tower.invoke_on_bell_rung.append(self._on_bell_ring)
+        self._tower.invoke_on_reset.append(self._on_size_change)
 
         self._is_ringing = False
         self._is_ringing_rounds = True
@@ -69,6 +70,11 @@ class Bot:
         return self._tower.number_of_bells
 
     # Callbacks
+    def _on_size_change(self):
+        if not self.row_generator.is_tower_size_valid(self._tower.number_of_bells):
+            print("WARNING: Row generation stage is NOT consistent with tower size! \
+Wheatley will crash when you go into changes unless something is done")
+
     def _on_look_to(self):
         """ Callback called when a user calls 'Look To'. """
 

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -13,7 +13,7 @@ import sys
 from wheatley.rhythm import RegressionRhythm, WaitForUserRhythm
 from wheatley.tower import RingingRoomTower
 from wheatley.bot import Bot
-from wheatley.page_parser import get_load_balancing_url
+from wheatley.page_parser import get_load_balancing_url, TowerNotFoundError
 from wheatley.row_generation import RowGenerator, ComplibCompositionGenerator
 from wheatley.row_generation import MethodPlaceNotationGenerator
 from wheatley.arg_parsing import parse_peal_speed, PealSpeedParseError, parse_call
@@ -215,7 +215,12 @@ def main():
     # Run the program
     configure_logging()
 
-    tower = RingingRoomTower(args.room_id, get_load_balancing_url(args.room_id, args.url))
+    try:
+        socket_url = get_load_balancing_url(args.room_id, args.url)
+    except TowerNotFoundError:
+        sys.exit(f"Invalid argument: Tower {args.room_id} not found at '{args.url}'.")
+
+    tower = RingingRoomTower(args.room_id, socket_url)
     bot = Bot(tower, row_generator(args), args.use_up_down_in or args.handbell_style,
               args.stop_at_rounds or args.handbell_style, rhythm=rhythm(args))
 

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -219,9 +219,7 @@ def main():
 
     try:
         socket_url = get_load_balancing_url(args.room_id, http_server_url)
-    except TowerNotFoundError:
-        sys.exit(f"Invalid argument: Tower {args.room_id} not found at '{http_server_url}'.")
-    except InvalidURLError as e:
+    except (TowerNotFoundError, InvalidURLError) as e:
         sys.exit(f"Invalid argument: {e}")
 
     tower = RingingRoomTower(args.room_id, socket_url)

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -38,7 +38,7 @@ def row_generator(args):
                 parse_call(args.single)
             )
         except MethodNotFoundError as e:
-            sys.exit(f"Invalid argument: {e}")
+            sys.exit(f"Bad value for '--method': {e}")
     else:
         assert False, \
             "This shouldn't be possible because one of --method and --comp should always be defined"
@@ -227,7 +227,7 @@ def main():
     try:
         socket_url = get_load_balancing_url(args.room_id, args.url)
     except (TowerNotFoundError, InvalidURLError) as e:
-        sys.exit(f"Invalid argument: {e}")
+        sys.exit(f"Bad value for 'room_id': {e}")
 
     tower = RingingRoomTower(args.room_id, socket_url)
     bot = Bot(tower, row_generator(args), args.use_up_down_in or args.handbell_style,

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -13,7 +13,7 @@ import sys
 from wheatley.rhythm import RegressionRhythm, WaitForUserRhythm
 from wheatley.tower import RingingRoomTower
 from wheatley.bot import Bot
-from wheatley.page_parser import get_load_balancing_url, TowerNotFoundError
+from wheatley.page_parser import fix_url, get_load_balancing_url, TowerNotFoundError
 from wheatley.row_generation import RowGenerator, ComplibCompositionGenerator
 from wheatley.row_generation import MethodPlaceNotationGenerator
 from wheatley.arg_parsing import parse_peal_speed, PealSpeedParseError, parse_call
@@ -215,10 +215,12 @@ def main():
     # Run the program
     configure_logging()
 
+    http_server_url = fix_url(args.url)
+
     try:
-        socket_url = get_load_balancing_url(args.room_id, args.url)
+        socket_url = get_load_balancing_url(args.room_id, http_server_url)
     except TowerNotFoundError:
-        sys.exit(f"Invalid argument: Tower {args.room_id} not found at '{args.url}'.")
+        sys.exit(f"Invalid argument: Tower {args.room_id} not found at '{http_server_url}'.")
 
     tower = RingingRoomTower(args.room_id, socket_url)
     bot = Bot(tower, row_generator(args), args.use_up_down_in or args.handbell_style,

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -226,8 +226,10 @@ def main():
 
     try:
         socket_url = get_load_balancing_url(args.room_id, args.url)
-    except (TowerNotFoundError, InvalidURLError) as e:
+    except TowerNotFoundError as e:
         sys.exit(f"Bad value for 'room_id': {e}")
+    except InvalidURLError as e:
+        sys.exit(f"Bad value for '--url': {e}")
 
     tower = RingingRoomTower(args.room_id, socket_url)
     bot = Bot(tower, row_generator(args), args.use_up_down_in or args.handbell_style,

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -13,7 +13,7 @@ import sys
 from wheatley.rhythm import RegressionRhythm, WaitForUserRhythm
 from wheatley.tower import RingingRoomTower
 from wheatley.bot import Bot
-from wheatley.page_parser import fix_url, get_load_balancing_url, TowerNotFoundError
+from wheatley.page_parser import *
 from wheatley.row_generation import RowGenerator, ComplibCompositionGenerator
 from wheatley.row_generation import MethodPlaceNotationGenerator
 from wheatley.arg_parsing import parse_peal_speed, PealSpeedParseError, parse_call
@@ -221,6 +221,8 @@ def main():
         socket_url = get_load_balancing_url(args.room_id, http_server_url)
     except TowerNotFoundError:
         sys.exit(f"Invalid argument: Tower {args.room_id} not found at '{http_server_url}'.")
+    except InvalidURLError as e:
+        sys.exit(f"Invalid argument: {e}")
 
     tower = RingingRoomTower(args.room_id, socket_url)
     bot = Bot(tower, row_generator(args), args.use_up_down_in or args.handbell_style,

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -14,9 +14,11 @@ from wheatley.rhythm import RegressionRhythm, WaitForUserRhythm
 from wheatley.tower import RingingRoomTower
 from wheatley.bot import Bot
 from wheatley.page_parser import get_load_balancing_url, TowerNotFoundError, InvalidURLError
+from wheatley.arg_parsing import parse_peal_speed, PealSpeedParseError, parse_call
+
 from wheatley.row_generation import RowGenerator, ComplibCompositionGenerator
 from wheatley.row_generation import MethodPlaceNotationGenerator
-from wheatley.arg_parsing import parse_peal_speed, PealSpeedParseError, parse_call
+from wheatley.row_generation.complib_composition_generator import PrivateCompError, InvalidCompError
 from wheatley.row_generation.method_place_notation_generator import MethodNotFoundError
 
 
@@ -24,7 +26,10 @@ def row_generator(args):
     """ Generates a row generator according to the given CLI arguments. """
 
     if "comp" in args and args.comp is not None:
-        row_gen = ComplibCompositionGenerator(args.comp)
+        try:
+            row_gen = ComplibCompositionGenerator(args.comp)
+        except (PrivateCompError, InvalidCompError) as e:
+            sys.exit(f"Bad value for '--comp': {e}")
     elif "method" in args:
         try:
             row_gen = MethodPlaceNotationGenerator(

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -17,6 +17,7 @@ from wheatley.page_parser import *
 from wheatley.row_generation import RowGenerator, ComplibCompositionGenerator
 from wheatley.row_generation import MethodPlaceNotationGenerator
 from wheatley.arg_parsing import parse_peal_speed, PealSpeedParseError, parse_call
+from wheatley.row_generation.method_place_notation_generator import MethodNotFoundError
 
 
 def row_generator(args):
@@ -25,11 +26,14 @@ def row_generator(args):
     if "comp" in args and args.comp is not None:
         row_gen = ComplibCompositionGenerator(args.comp)
     elif "method" in args:
-        row_gen = MethodPlaceNotationGenerator(
-            args.method,
-            parse_call(args.bob),
-            parse_call(args.single)
-        )
+        try:
+            row_gen = MethodPlaceNotationGenerator(
+                args.method,
+                parse_call(args.bob),
+                parse_call(args.single)
+            )
+        except MethodNotFoundError as e:
+            sys.exit(f"Invalid argument: {e}")
     else:
         assert False, \
             "This shouldn't be possible because one of --method and --comp should always be defined"

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -13,7 +13,7 @@ import sys
 from wheatley.rhythm import RegressionRhythm, WaitForUserRhythm
 from wheatley.tower import RingingRoomTower
 from wheatley.bot import Bot
-from wheatley.page_parser import *
+from wheatley.page_parser import get_load_balancing_url, TowerNotFoundError, InvalidURLError
 from wheatley.row_generation import RowGenerator, ComplibCompositionGenerator
 from wheatley.row_generation import MethodPlaceNotationGenerator
 from wheatley.arg_parsing import parse_peal_speed, PealSpeedParseError, parse_call

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -215,10 +215,8 @@ def main():
     # Run the program
     configure_logging()
 
-    http_server_url = fix_url(args.url)
-
     try:
-        socket_url = get_load_balancing_url(args.room_id, http_server_url)
+        socket_url = get_load_balancing_url(args.room_id, args.url)
     except (TowerNotFoundError, InvalidURLError) as e:
         sys.exit(f"Invalid argument: {e}")
 

--- a/wheatley/page_parser.py
+++ b/wheatley/page_parser.py
@@ -11,12 +11,13 @@ import requests
 class TowerNotFoundError(ValueError):
     """ An error class created whenever the user inputs an incorrect room id. """
 
-    def __init__(self, tower_id):
+    def __init__(self, tower_id, url):
         super().__init__()
         self._id = tower_id
+        self._url = url
 
     def __str__(self):
-        return f"Tower {self._id} not found."
+        return f"Tower {self._id} not found at '{self._url}'."
 
 class InvalidURLError(Exception):
     """ An error class created whenever the user inputs a URL that is invalid. """
@@ -63,4 +64,4 @@ def get_load_balancing_url(tower_id, http_server_url):
 
         return load_balancing_url
     except ValueError:
-        raise TowerNotFoundError(tower_id)
+        raise TowerNotFoundError(tower_id, http_server_url)

--- a/wheatley/page_parser.py
+++ b/wheatley/page_parser.py
@@ -8,6 +8,17 @@ import urllib
 import requests
 
 
+class TowerNotFoundError(ValueError):
+    """ An error class created whenever the user inputs an incorrect room id. """
+
+    def __init__(self, tower_id):
+        super().__init__()
+        self._id = tower_id
+
+    def __str__(self):
+        return f"Tower {self._id} not found."
+
+
 def get_load_balancing_url(tower_id, http_server_url):
     """
     Get the URL of the socket server which (since the addition of load balancing) is not
@@ -22,8 +33,11 @@ def get_load_balancing_url(tower_id, http_server_url):
     url = urllib.parse.urljoin(http_server_url, str(tower_id))
     html = requests.get(url).text
 
-    url_start_index = html.index("server_ip") + len('server_ip: "')
-    string_that_starts_with_url = html[url_start_index:]
-    load_balancing_url = string_that_starts_with_url[:string_that_starts_with_url.index('"')]
+    try:
+        url_start_index = html.index("server_ip") + len('server_ip: "')
+        string_that_starts_with_url = html[url_start_index:]
+        load_balancing_url = string_that_starts_with_url[:string_that_starts_with_url.index('"')]
 
-    return load_balancing_url
+        return load_balancing_url
+    except ValueError:
+        raise TowerNotFoundError(tower_id)

--- a/wheatley/page_parser.py
+++ b/wheatley/page_parser.py
@@ -18,6 +18,16 @@ class TowerNotFoundError(ValueError):
     def __str__(self):
         return f"Tower {self._id} not found."
 
+class InvalidURLError(Exception):
+    """ An error class created whenever the user inputs a URL that is invalid. """
+
+    def __init__(self, url):
+        super().__init__()
+        self._url = url
+
+    def __str__(self):
+        return f"Unable to make a connection to '{self._url}'."
+
 
 def fix_url(url):
     """ Add 'https://' to the start of a URL if necessary """
@@ -40,7 +50,11 @@ def get_load_balancing_url(tower_id, http_server_url):
     # See https://github.com/lelandpaul/virtual-ringing-room/blob/
     #     ec00927ca57ab94fa2ff6a978ffaff707ab23a57/app/templates/ringing_room.html#L46
     url = urllib.parse.urljoin(http_server_url, str(tower_id))
-    html = requests.get(url).text
+
+    try:
+        html = requests.get(url).text
+    except requests.exceptions.ConnectionError:
+        raise InvalidURLError(http_server_url)
 
     try:
         url_start_index = html.index("server_ip") + len('server_ip: "')

--- a/wheatley/page_parser.py
+++ b/wheatley/page_parser.py
@@ -30,21 +30,22 @@ class InvalidURLError(Exception):
         return f"Unable to make a connection to '{self._url}'."
 
 
-def fix_url(url):
+def _fix_url(url):
     """ Add 'https://' to the start of a URL if necessary """
 
-    if not url.startswith("http"):
-        return "https://" + url
+    corrected_url = url if url.startswith("http") else "https://" + url
 
-    return url
+    return corrected_url
 
 
-def get_load_balancing_url(tower_id, http_server_url):
+def get_load_balancing_url(tower_id, unfixed_http_server_url):
     """
     Get the URL of the socket server which (since the addition of load balancing) is not
     necessarily the same as the URL of the http server that people will put into their browser URL
     bars.
     """
+
+    http_server_url = _fix_url(unfixed_http_server_url)
 
     # Trying to extract the following line in the rendered html:
     # server_ip: "{{server_ip}}"

--- a/wheatley/page_parser.py
+++ b/wheatley/page_parser.py
@@ -19,6 +19,15 @@ class TowerNotFoundError(ValueError):
         return f"Tower {self._id} not found."
 
 
+def fix_url(url):
+    """ Add 'https://' to the start of a URL if necessary """
+
+    if not url.startswith("http"):
+        return "https://" + url
+
+    return url
+
+
 def get_load_balancing_url(tower_id, http_server_url):
     """
     Get the URL of the socket server which (since the addition of load balancing) is not

--- a/wheatley/row_generation/complib_composition_generator.py
+++ b/wheatley/row_generation/complib_composition_generator.py
@@ -8,6 +8,30 @@ from wheatley.bell import Bell
 from .row_generator import RowGenerator
 
 
+class PrivateCompError(ValueError):
+    """ An error class thrown when a user tries to access a private CompLib composition. """
+
+    def __init__(self, comp_id):
+        super().__init__()
+
+        self._comp_id = comp_id
+
+    def __str__(self):
+        return f"Composition with ID {self._comp_id} is private."
+
+
+class InvalidCompError(ValueError):
+    """ An error class thrown when a user tries to access an invalid CompLib composition. """
+
+    def __init__(self, comp_id):
+        super().__init__()
+
+        self._comp_id = comp_id
+
+    def __str__(self):
+        return f"Composition with ID {self._comp_id} is does not exist."
+
+
 class ComplibCompositionGenerator(RowGenerator):
     """ The RowGenerator subclass for generating rows from a CompLib composition. """
 
@@ -16,6 +40,13 @@ class ComplibCompositionGenerator(RowGenerator):
     def __init__(self, comp_id: int):
         url = self.complib_url + str(comp_id) + "/rows"
         request_rows = requests.get(url)
+
+        if request_rows.status_code == 404:
+            raise InvalidCompError(comp_id)
+
+        if request_rows.status_code == 403:
+            raise PrivateCompError(comp_id)
+
         request_rows.raise_for_status()
 
         # New line separated, skip the first line (rounds)

--- a/wheatley/row_generation/method_place_notation_generator.py
+++ b/wheatley/row_generation/method_place_notation_generator.py
@@ -8,6 +8,11 @@ from .place_notation_generator import PlaceNotationGenerator
 
 
 class MethodNotFoundError(ValueError):
+    """
+    An error class to store the error thrown when a method title is inputted that doesn't have an
+    entry in the CC method library.
+    """
+
     def __init__(self, name):
         super().__init__()
         self._name = name

--- a/wheatley/row_generation/method_place_notation_generator.py
+++ b/wheatley/row_generation/method_place_notation_generator.py
@@ -7,12 +7,26 @@ import requests
 from .place_notation_generator import PlaceNotationGenerator
 
 
+class MethodNotFoundError(ValueError):
+    def __init__(self, name):
+        super().__init__()
+        self._name = name
+
+    def __str__(self):
+        return f"No method with title '{self._name}' found."
+
+
 class MethodPlaceNotationGenerator(PlaceNotationGenerator):
     """ A class to generate rows given a method title. """
 
     def __init__(self, method_title: str, bob, single):
         method_xml = self._fetch_method(method_title)
-        method_pn, stage = self._parse_xml(method_xml)
+
+        try:
+            method_pn, stage = self._parse_xml(method_xml)
+        except AttributeError:
+            raise MethodNotFoundError(method_title)
+
         super(MethodPlaceNotationGenerator, self).__init__(
             stage,
             method_pn,

--- a/wheatley/row_generation/row_generator.py
+++ b/wheatley/row_generation/row_generator.py
@@ -29,7 +29,7 @@ class RowGenerator(metaclass=ABCMeta):
         Returns True if the row_generator can generate rows correctly for a given tower size.
         """
 
-        return tower_size in [self.stage, self.stage + 1]
+        return tower_size == self.number_of_bells
 
     def reset(self):
         """ Reset the row generator. """

--- a/wheatley/row_generation/row_generator.py
+++ b/wheatley/row_generation/row_generator.py
@@ -22,6 +22,7 @@ class RowGenerator(metaclass=ABCMeta):
         self._has_bob = False
         self._has_single = False
         self._index = 0
+        self._row = self.rounds()
 
     def is_tower_size_valid(self, tower_size) -> bool:
         """

--- a/wheatley/row_generation/row_generator.py
+++ b/wheatley/row_generation/row_generator.py
@@ -22,7 +22,13 @@ class RowGenerator(metaclass=ABCMeta):
         self._has_bob = False
         self._has_single = False
         self._index = 0
-        self._row = self.rounds()
+
+    def is_tower_size_valid(self, tower_size) -> bool:
+        """
+        Returns True if the row_generator can generate rows correctly for a given tower size.
+        """
+
+        return tower_size in [self.stage, self.stage + 1]
 
     def reset(self):
         """ Reset the row generator. """

--- a/wheatley/tower.py
+++ b/wheatley/tower.py
@@ -97,7 +97,7 @@ class RingingRoomTower:
     def set_at_hand(self):
         """ Sets all the bells at hand. """
 
-        self._emit("c_set_bells", {"tower_id": self.tower_id}, f"Set at hand")
+        self._emit("c_set_bells", {"tower_id": self.tower_id}, "Set at hand")
 
     def set_number_of_bells(self, number: int):
         """ Set the number of bells in the tower. """
@@ -181,6 +181,9 @@ class RingingRoomTower:
         self._bell_state = bell_state
 
         self.logger.debug(f"RECEIVED: Bells '{['H' if x else 'B' for x in bell_state]}'")
+
+        for invoke_callback in self.invoke_on_reset:
+            invoke_callback()
 
     def _on_size_change(self, data):
         """ Callback called when the number of bells in the room changes. """


### PR DESCRIPTION
This PR fixes #54 and resolves #52.

## New error messages:

### Inputting an invalid method name:
Running `wheatley 389217546 --method "Plain Bob Maj"` outputs:
```
Bad value for '--method': No method with title 'Plain Bob Maj' found.
```
---

### Inputting the ID of a non-existent CompLib comp:
Running `wheatley 389217546 --comp 1` outputs:
```
Bad value for '--comp': Composition with ID 1 is does not exist on CompLib.
```
---

### Inputting the ID of a private CompLib comp:
Running `wheatley 389217546 --comp 64513` outputs:
```
Bad value for '--comp': Composition with ID 64513 is private on CompLib.
```
---

### Inputting the ID of a tower that doesn't exist on the given URL:
Running `wheatley 38921754 --method "Plain Bob Major"` outputs:
```
Bad value for 'room_id': Tower 38921754 not found at 'https://ringingroom.com'.
```
---

### Inputting an invalid Ringing Room URL:
Running `wheatley 38921754 --method "Plain Bob Major" --url 'ringroo.com'` outputs:
```
Bad value for '--url': Unable to make a connection to 'https://ringroo.com'.
```


## Smaller changes:
- Added a warning if you are about to ring a method or comp that is not valid for the current tower size (re-emits every time the tower size is changed).
- `get_load_balancing_url` now adds `https://` and removes page paths from the given URL if required.

I'm going to change the code so that it doesn't exit at the first error message, but rather keeps running and logging error messages right until it reaches the call into the `Bot` class's mainloop - and at this point it will either continue if no errors have been produced, or it will print _all_ the errors and exit.  After that, I'll stop it being a draft.