### PR TITLE
Waiting rhythm and tests

### DIFF
--- a/tests/test_wait_for_user_rhythm.py
+++ b/tests/test_wait_for_user_rhythm.py
@@ -1,0 +1,103 @@
+import time
+import unittest
+from threading import Thread
+
+from unittest.mock import Mock, patch
+
+from wheatley.bell import Bell
+from wheatley.rhythm import Rhythm, WaitForUserRhythm
+
+
+treble = Bell.from_number(1)
+second = Bell.from_number(2)
+
+handstroke = True
+backstroke = False
+
+
+class WaitForUserRhythmTests(unittest.TestCase):
+    def setUp(self):
+        self.mock_inner_rhythm = Mock(spec=Rhythm)
+        self.wait_rhythm = WaitForUserRhythm(self.mock_inner_rhythm)
+        self.wait_rhythm.sleep = self._patched_sleep
+
+        self.waiting_for_bell_time = False
+
+        self._sleeping = False
+        self._return_from_sleep = False
+        self.total_sleep_calls = 0
+        self.total_sleep_delay = 0
+
+    def _patched_sleep(self, seconds):
+        self._sleeping = True
+        self.total_sleep_calls += 1
+        self.total_sleep_delay += seconds
+        while not self._return_from_sleep:
+            time.sleep(0.001)
+        self._return_from_sleep = False
+        self._sleeping = False
+
+    def return_from_sleep(self, wait_for_sleep=True):
+        while wait_for_sleep and not self._sleeping or self._return_from_sleep:
+            time.sleep(0.001)
+        self._return_from_sleep = True
+
+    def start_wait_for_bell_time(self, current_time, bell, row_number, place, user_controlled, stroke):
+        # Run on a different thread as it will loop until on_bell_ring called.
+        def _wait_for_bell_time():
+            self.waiting_for_bell_time = True
+            self.wait_rhythm.wait_for_bell_time(current_time, bell, row_number, place, user_controlled, stroke)
+            self.waiting_for_bell_time = False
+
+        wait_thread = Thread(name="wait_for_bell_time", target=_wait_for_bell_time)
+        wait_thread.start()
+
+    def assert_not_waiting_for_bell_time(self):
+        count = 0
+        while self.waiting_for_bell_time and count < 100:
+            time.sleep(0.001)
+            count += 1
+        self.assertFalse(self.waiting_for_bell_time)
+
+    def test_on_bell_ring__no_initial_delay(self):
+        self.wait_rhythm.expect_bell(treble, 1, 1, handstroke)
+
+        self.wait_rhythm.on_bell_ring(treble, handstroke, 0.5)
+
+        self.mock_inner_rhythm.on_bell_ring.assert_called_once_with(treble, handstroke, 0.5)
+
+    def test_on_bell_ring__subtracts_existing_delay(self):
+        self.wait_rhythm.expect_bell(treble, 1, 1, handstroke)
+        self.wait_rhythm.delay = 10
+
+        self.wait_rhythm.on_bell_ring(treble, handstroke, 10.5)
+
+        self.mock_inner_rhythm.on_bell_ring.assert_called_once_with(treble, handstroke, 0.5)
+
+    def test_on_bell_ring__uses_original_delay_while_waiting(self):
+        initial_delay = 10
+        expected_time = 11
+        actual_time = 11.1
+
+        self.wait_rhythm.expect_bell(treble, 1, 1, handstroke)
+        self.wait_rhythm.delay = initial_delay
+
+        self.start_wait_for_bell_time(current_time=expected_time, bell=treble, row_number=1, place=1,
+                                      user_controlled=True, stroke=handstroke)
+
+        expected_sleeps = (actual_time - expected_time)/WaitForUserRhythm.sleep_time
+        for _ in range(round(expected_sleeps)):
+            self.return_from_sleep()
+
+        self.wait_rhythm.on_bell_ring(treble, handstroke, actual_time)
+        self.return_from_sleep(wait_for_sleep=False)
+        self.assert_not_waiting_for_bell_time()
+
+        # 11.1 - 10 = 1.1
+        self.mock_inner_rhythm.on_bell_ring.assert_called_once_with(treble, handstroke, actual_time - initial_delay)
+        # 10 + (11.1 - 11) = 10.1
+        self.assertEqual(10.1, round(self.wait_rhythm.delay, 2))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_wait_for_user_rhythm.py
+++ b/tests/test_wait_for_user_rhythm.py
@@ -32,6 +32,9 @@ class WaitForUserRhythmTests(unittest.TestCase):
         self._finished_test = True
 
     def _patched_sleep(self, seconds):
+        """ Replacement sleep function that loops until advance_patched_sleep() is called
+        Allows controlling how many times sleep() returns.
+        """
         self._sleeping = True
         self.total_sleep_calls += 1
         self.total_sleep_delay += seconds
@@ -40,31 +43,38 @@ class WaitForUserRhythmTests(unittest.TestCase):
         self._return_from_sleep = False
         self._sleeping = False
 
-    def return_from_sleep(self, seconds: float = 0.01, wait_for_sleep=True):
+    def advance_patched_sleep(self, seconds: float = 0.01):
+        """ Makes _patched_sleep() return
+        Allows controlling how many times sleep() returns.
+        """
         expected_sleeps = seconds / WaitForUserRhythm.sleep_time
         for _ in range(round(expected_sleeps)):
-            while wait_for_sleep and not self._sleeping or self._return_from_sleep:
+            while not self._sleeping or self._return_from_sleep:
                 time.sleep(0.001)
             self._return_from_sleep = True
 
-    def start_wait_for_bell_time(self, current_time, bell, row_number, place, user_controlled, stroke):
-        # Run on a different thread as it will loop until on_bell_ring called.
+    def start_wait_for_bell_time_thread(self, current_time, bell, row_number, place, user_controlled, stroke):
+        """ Runs wait_for_bell_time() on a different thread, as it should loop until on_bell_ring() is called
+        """
         def _wait_for_bell_time():
             self.waiting_for_bell_time = True
             self.wait_rhythm.wait_for_bell_time(current_time, bell, row_number, place, user_controlled, stroke)
             self.waiting_for_bell_time = False
 
-        wait_thread = Thread(name="wait_for_bell_time", target=_wait_for_bell_time)
+        wait_thread = Thread(name=f"wait_for_bell_time_{bell}", target=_wait_for_bell_time)
         wait_thread.start()
 
     def assert_not_waiting_for_bell_time(self):
         count = 0
+        # Return from a last sleep just in case
+        self._return_from_sleep = True
         time.sleep(0.01)
 
-        while self.waiting_for_bell_time and count < 100:
+        while self.waiting_for_bell_time and count < 50:
             time.sleep(0.001)
             count += 1
         self.assertFalse(self.waiting_for_bell_time, "Waiting for bell to ring")
+        self._return_from_sleep = False
 
     def test_on_bell_ring__no_initial_delay(self):
         self.wait_rhythm.expect_bell(treble, 1, 1, handstroke)
@@ -82,6 +92,7 @@ class WaitForUserRhythmTests(unittest.TestCase):
         self.mock_inner_rhythm.on_bell_ring.assert_called_once_with(treble, handstroke, 0.5)
 
     def test_on_bell_ring__uses_original_delay_while_waiting(self):
+        # Arrange
         initial_delay = 10
         expected_time = 11
         actual_time = 11.1
@@ -89,13 +100,14 @@ class WaitForUserRhythmTests(unittest.TestCase):
         self.wait_rhythm.expect_bell(treble, 1, 1, handstroke)
         self.wait_rhythm.delay = initial_delay
 
-        self.start_wait_for_bell_time(current_time=expected_time, bell=treble, row_number=1, place=1,
-                                      user_controlled=True, stroke=handstroke)
+        # Start waiting for treble
+        self.start_wait_for_bell_time_thread(current_time=expected_time, bell=treble, row_number=1, place=1,
+                                             user_controlled=True, stroke=handstroke)
 
-        self.return_from_sleep(seconds=actual_time - expected_time)
+        self.advance_patched_sleep(seconds=actual_time - expected_time)
 
+        # Treble rung by user
         self.wait_rhythm.on_bell_ring(treble, handstroke, actual_time)
-        self.return_from_sleep(wait_for_sleep=False)
         self.assert_not_waiting_for_bell_time()
 
         # 11.1 - 10 = 1.1
@@ -103,7 +115,30 @@ class WaitForUserRhythmTests(unittest.TestCase):
         # 10 + (11.1 - 11) = 10.1
         self.assertEqual(10.1, round(self.wait_rhythm.delay, 2))
 
+    def test_wait_for_bell_time__bell_rung_early_doesnt_wait(self):
+        # Arrange
+        initial_delay = 10
+        expected_time = 11
+        actual_time = 10.5
+
+        self.wait_rhythm.delay = initial_delay
+        self.wait_rhythm.expect_bell(treble, 1, 1, handstroke)
+
+        # Treble rung by user
+        self.wait_rhythm.on_bell_ring(treble, handstroke, actual_time)
+
+        # Start waiting for treble
+        self.start_wait_for_bell_time_thread(current_time=expected_time, bell=treble, row_number=1, place=1,
+                                             user_controlled=True, stroke=handstroke)
+
+        # Returns immediately without waiting
+        self.assert_not_waiting_for_bell_time()
+
+        self.mock_inner_rhythm.on_bell_ring.assert_called_once_with(treble, handstroke, actual_time - initial_delay)
+        self.assertEqual(initial_delay, self.wait_rhythm.delay)
+
     def test_wait_for_bell_time__bell_rung_early_in_row_doesnt_wait(self):
+        # Arrange
         initial_delay = 0
         expected_first_bell_time = 1
         expected_second_bell_time = 2
@@ -112,28 +147,35 @@ class WaitForUserRhythmTests(unittest.TestCase):
         self.wait_rhythm.expect_bell(second, 1, 2, handstroke)
         self.wait_rhythm.delay = initial_delay
 
-        self.start_wait_for_bell_time(current_time=expected_first_bell_time, bell=treble, row_number=1, place=1,
-                                      user_controlled=True, stroke=handstroke)
+        # Start waiting for treble
+        self.start_wait_for_bell_time_thread(current_time=expected_first_bell_time, bell=treble, row_number=1, place=1,
+                                             user_controlled=True, stroke=handstroke)
 
-        self.return_from_sleep(seconds=0.1)
+        self.advance_patched_sleep(seconds=0.05)
 
-        self.wait_rhythm.on_bell_ring(second, handstroke, 1.1)
+        # Second rung early by user
+        self.wait_rhythm.on_bell_ring(second, handstroke, 1.05)
 
-        self.return_from_sleep(seconds=0.1)
+        self.advance_patched_sleep(seconds=0.05)
         self.assertTrue(self.waiting_for_bell_time)
-        self.wait_rhythm.on_bell_ring(treble, handstroke, 1.2)
-        self.return_from_sleep(wait_for_sleep=False)
-        self.assert_not_waiting_for_bell_time()
-        self.start_wait_for_bell_time(current_time=expected_second_bell_time, bell=second, row_number=1, place=1,
-                                      user_controlled=True, stroke=handstroke)
+
+        # Treble rung by user
+        self.wait_rhythm.on_bell_ring(treble, handstroke, 1.1)
         self.assert_not_waiting_for_bell_time()
 
-        self.mock_inner_rhythm.on_bell_ring.assert_any_call(second, handstroke, 1.1)
-        self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, handstroke, 1.2)
-        # 1.2 - 1, Second being early has not added delay
-        self.assertEqual(0.2, round(self.wait_rhythm.delay, 2))
+        # Start waiting for second
+        self.start_wait_for_bell_time_thread(current_time=expected_second_bell_time, bell=second, row_number=1, place=1,
+                                             user_controlled=True, stroke=handstroke)
+        # Returns immediately without waiting
+        self.assert_not_waiting_for_bell_time()
+
+        self.mock_inner_rhythm.on_bell_ring.assert_any_call(second, handstroke, 1.05)
+        self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, handstroke, 1.1)
+        # 1.1 - 1, Second being early has not added delay
+        self.assertEqual(0.1, round(self.wait_rhythm.delay, 2))
 
     def test_wait_for_bell_time__bell_rung_early_in_previous_row_doesnt_wait(self):
+        # Arrange
         initial_delay = 0
         expected_first_time = 1
         expected_second_time = 2
@@ -141,43 +183,44 @@ class WaitForUserRhythmTests(unittest.TestCase):
         self.wait_rhythm.expect_bell(treble, 1, 1, handstroke)
         self.wait_rhythm.delay = initial_delay
 
+        # Treble rung by user twice, so is now on wrong stroke
         self.wait_rhythm.on_bell_ring(treble, handstroke, 1)
-
-        self.start_wait_for_bell_time(current_time=expected_first_time, bell=treble, row_number=1, place=1,
-                                      user_controlled=True, stroke=handstroke)
-
         self.wait_rhythm.on_bell_ring(treble, backstroke, 1.1)
 
-        self.return_from_sleep(wait_for_sleep=False)
+        self.start_wait_for_bell_time_thread(current_time=expected_first_time, bell=treble, row_number=1, place=1,
+                                             user_controlled=True, stroke=handstroke)
         self.assert_not_waiting_for_bell_time()
 
         self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, handstroke, 1)
         self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, backstroke, 1.1)
 
+        # Next row, treble is already rung backstroke
         self.wait_rhythm.expect_bell(treble, 2, 1, backstroke)
 
-        self.start_wait_for_bell_time(current_time=expected_second_time, bell=treble, row_number=2, place=1,
-                                      user_controlled=True, stroke=backstroke)
+        self.start_wait_for_bell_time_thread(current_time=expected_second_time, bell=treble, row_number=2, place=1,
+                                             user_controlled=True, stroke=backstroke)
 
         self.assert_not_waiting_for_bell_time()
 
         self.assertEqual(0, self.wait_rhythm.delay)
 
     def test_wait_for_bell_time__bell_early_and_corrected_in_previous_row_waits_for_bell(self):
+        # Arrange
         expected_first_time = 1
         expected_second_time = 2
 
         self.wait_rhythm.expect_bell(treble, 1, 1, handstroke)
 
+        # Treble rung by user
         self.wait_rhythm.on_bell_ring(treble, handstroke, 1)
 
-        self.start_wait_for_bell_time(current_time=expected_first_time, bell=treble, row_number=1, place=1,
-                                      user_controlled=True, stroke=handstroke)
+        self.start_wait_for_bell_time_thread(current_time=expected_first_time, bell=treble, row_number=1, place=1,
+                                             user_controlled=True, stroke=handstroke)
 
+        # Treble accidentally rung by user and corrected back to the right stroke
         self.wait_rhythm.on_bell_ring(treble, backstroke, 1.1)
         self.wait_rhythm.on_bell_ring(treble, handstroke, 1.2)
 
-        self.return_from_sleep(wait_for_sleep=False)
         self.assert_not_waiting_for_bell_time()
 
         self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, handstroke, 1)
@@ -186,8 +229,8 @@ class WaitForUserRhythmTests(unittest.TestCase):
 
         self.wait_rhythm.expect_bell(treble, 2, 1, backstroke)
 
-        self.start_wait_for_bell_time(current_time=expected_second_time, bell=treble, row_number=2, place=1,
-                                      user_controlled=True, stroke=backstroke)
+        self.start_wait_for_bell_time_thread(current_time=expected_second_time, bell=treble, row_number=2, place=1,
+                                             user_controlled=True, stroke=backstroke)
 
         self.assertTrue(self.waiting_for_bell_time)
 

--- a/tests/test_wait_for_user_rhythm.py
+++ b/tests/test_wait_for_user_rhythm.py
@@ -6,12 +6,10 @@ from unittest.mock import Mock
 
 from wheatley.bell import Bell
 from wheatley.rhythm import Rhythm, WaitForUserRhythm
+from wheatley.tower import HANDSTROKE, BACKSTROKE
 
 treble = Bell.from_number(1)
 second = Bell.from_number(2)
-
-handstroke = True
-backstroke = False
 
 
 class WaitForUserRhythmTests(unittest.TestCase):
@@ -56,9 +54,11 @@ class WaitForUserRhythmTests(unittest.TestCase):
     def start_wait_for_bell_time_thread(self, current_time, bell, row_number, place, user_controlled, stroke):
         """ Runs wait_for_bell_time() on a different thread, as it should loop until on_bell_ring() is called
         """
+
         def _wait_for_bell_time():
             self.waiting_for_bell_time = True
-            self.wait_rhythm.wait_for_bell_time(current_time, bell, row_number, place, user_controlled, stroke)
+            self.wait_rhythm.wait_for_bell_time(current_time, bell, row_number, place, user_controlled,
+                                                stroke)
             self.waiting_for_bell_time = False
 
         wait_thread = Thread(name=f"wait_for_bell_time_{bell}", target=_wait_for_bell_time)
@@ -77,19 +77,19 @@ class WaitForUserRhythmTests(unittest.TestCase):
         self._return_from_sleep = False
 
     def test_on_bell_ring__no_initial_delay(self):
-        self.wait_rhythm.expect_bell(treble, 1, 1, handstroke)
+        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE)
 
-        self.wait_rhythm.on_bell_ring(treble, handstroke, 0.5)
+        self.wait_rhythm.on_bell_ring(treble, HANDSTROKE, 0.5)
 
-        self.mock_inner_rhythm.on_bell_ring.assert_called_once_with(treble, handstroke, 0.5)
+        self.mock_inner_rhythm.on_bell_ring.assert_called_once_with(treble, HANDSTROKE, 0.5)
 
     def test_on_bell_ring__subtracts_existing_delay(self):
-        self.wait_rhythm.expect_bell(treble, 1, 1, handstroke)
+        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE)
         self.wait_rhythm.delay = 10
 
-        self.wait_rhythm.on_bell_ring(treble, handstroke, 10.5)
+        self.wait_rhythm.on_bell_ring(treble, HANDSTROKE, 10.5)
 
-        self.mock_inner_rhythm.on_bell_ring.assert_called_once_with(treble, handstroke, 0.5)
+        self.mock_inner_rhythm.on_bell_ring.assert_called_once_with(treble, HANDSTROKE, 0.5)
 
     def test_on_bell_ring__uses_original_delay_while_waiting(self):
         # Arrange
@@ -97,21 +97,22 @@ class WaitForUserRhythmTests(unittest.TestCase):
         expected_time = 11
         actual_time = 11.1
 
-        self.wait_rhythm.expect_bell(treble, 1, 1, handstroke)
+        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE)
         self.wait_rhythm.delay = initial_delay
 
         # Start waiting for treble
         self.start_wait_for_bell_time_thread(current_time=expected_time, bell=treble, row_number=1, place=1,
-                                             user_controlled=True, stroke=handstroke)
+                                             user_controlled=True, stroke=HANDSTROKE)
 
         self.advance_patched_sleep(seconds=actual_time - expected_time)
 
         # Treble rung by user
-        self.wait_rhythm.on_bell_ring(treble, handstroke, actual_time)
+        self.wait_rhythm.on_bell_ring(treble, HANDSTROKE, actual_time)
         self.assert_not_waiting_for_bell_time()
 
         # 11.1 - 10 = 1.1
-        self.mock_inner_rhythm.on_bell_ring.assert_called_once_with(treble, handstroke, actual_time - initial_delay)
+        self.mock_inner_rhythm.on_bell_ring.assert_called_once_with(treble, HANDSTROKE,
+                                                                    actual_time - initial_delay)
         # 10 + (11.1 - 11) = 10.1
         self.assertEqual(10.1, round(self.wait_rhythm.delay, 2))
 
@@ -122,19 +123,20 @@ class WaitForUserRhythmTests(unittest.TestCase):
         actual_time = 10.5
 
         self.wait_rhythm.delay = initial_delay
-        self.wait_rhythm.expect_bell(treble, 1, 1, handstroke)
+        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE)
 
         # Treble rung by user
-        self.wait_rhythm.on_bell_ring(treble, handstroke, actual_time)
+        self.wait_rhythm.on_bell_ring(treble, HANDSTROKE, actual_time)
 
         # Start waiting for treble
         self.start_wait_for_bell_time_thread(current_time=expected_time, bell=treble, row_number=1, place=1,
-                                             user_controlled=True, stroke=handstroke)
+                                             user_controlled=True, stroke=HANDSTROKE)
 
         # Returns immediately without waiting
         self.assert_not_waiting_for_bell_time()
 
-        self.mock_inner_rhythm.on_bell_ring.assert_called_once_with(treble, handstroke, actual_time - initial_delay)
+        self.mock_inner_rhythm.on_bell_ring.assert_called_once_with(treble, HANDSTROKE,
+                                                                    actual_time - initial_delay)
         self.assertEqual(initial_delay, self.wait_rhythm.delay)
 
     def test_wait_for_bell_time__bell_rung_early_in_row_doesnt_wait(self):
@@ -143,34 +145,34 @@ class WaitForUserRhythmTests(unittest.TestCase):
         expected_first_bell_time = 1
         expected_second_bell_time = 2
 
-        self.wait_rhythm.expect_bell(treble, 1, 1, handstroke)
-        self.wait_rhythm.expect_bell(second, 1, 2, handstroke)
+        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE)
+        self.wait_rhythm.expect_bell(second, 1, 2, HANDSTROKE)
         self.wait_rhythm.delay = initial_delay
 
         # Start waiting for treble
-        self.start_wait_for_bell_time_thread(current_time=expected_first_bell_time, bell=treble, row_number=1, place=1,
-                                             user_controlled=True, stroke=handstroke)
+        self.start_wait_for_bell_time_thread(current_time=expected_first_bell_time, bell=treble, row_number=1,
+                                             place=1, user_controlled=True, stroke=HANDSTROKE)
 
         self.advance_patched_sleep(seconds=0.05)
 
         # Second rung early by user
-        self.wait_rhythm.on_bell_ring(second, handstroke, 1.05)
+        self.wait_rhythm.on_bell_ring(second, HANDSTROKE, 1.05)
 
         self.advance_patched_sleep(seconds=0.05)
         self.assertTrue(self.waiting_for_bell_time)
 
         # Treble rung by user
-        self.wait_rhythm.on_bell_ring(treble, handstroke, 1.1)
+        self.wait_rhythm.on_bell_ring(treble, HANDSTROKE, 1.1)
         self.assert_not_waiting_for_bell_time()
 
         # Start waiting for second
-        self.start_wait_for_bell_time_thread(current_time=expected_second_bell_time, bell=second, row_number=1, place=1,
-                                             user_controlled=True, stroke=handstroke)
+        self.start_wait_for_bell_time_thread(current_time=expected_second_bell_time, bell=second,
+                                             row_number=1, place=1, user_controlled=True, stroke=HANDSTROKE)
         # Returns immediately without waiting
         self.assert_not_waiting_for_bell_time()
 
-        self.mock_inner_rhythm.on_bell_ring.assert_any_call(second, handstroke, 1.05)
-        self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, handstroke, 1.1)
+        self.mock_inner_rhythm.on_bell_ring.assert_any_call(second, HANDSTROKE, 1.05)
+        self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, HANDSTROKE, 1.1)
         # 1.1 - 1, Second being early has not added delay
         self.assertEqual(0.1, round(self.wait_rhythm.delay, 2))
 
@@ -180,64 +182,64 @@ class WaitForUserRhythmTests(unittest.TestCase):
         expected_first_time = 1
         expected_second_time = 2
 
-        self.wait_rhythm.expect_bell(treble, 1, 1, handstroke)
+        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE)
         self.wait_rhythm.delay = initial_delay
 
         # Treble rung by user twice, so is now on wrong stroke
-        self.wait_rhythm.on_bell_ring(treble, handstroke, 1)
-        self.wait_rhythm.on_bell_ring(treble, backstroke, 1.1)
+        self.wait_rhythm.on_bell_ring(treble, HANDSTROKE, 1)
+        self.wait_rhythm.on_bell_ring(treble, BACKSTROKE, 1.1)
 
-        self.start_wait_for_bell_time_thread(current_time=expected_first_time, bell=treble, row_number=1, place=1,
-                                             user_controlled=True, stroke=handstroke)
+        self.start_wait_for_bell_time_thread(current_time=expected_first_time, bell=treble, row_number=1,
+                                             place=1, user_controlled=True, stroke=HANDSTROKE)
         self.assert_not_waiting_for_bell_time()
 
-        self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, handstroke, 1)
-        self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, backstroke, 1.1)
+        # Next row, treble is already rung BACKSTROKE
+        self.wait_rhythm.expect_bell(treble, 2, 1, BACKSTROKE)
 
-        # Next row, treble is already rung backstroke
-        self.wait_rhythm.expect_bell(treble, 2, 1, backstroke)
-
-        self.start_wait_for_bell_time_thread(current_time=expected_second_time, bell=treble, row_number=2, place=1,
-                                             user_controlled=True, stroke=backstroke)
+        self.start_wait_for_bell_time_thread(current_time=expected_second_time, bell=treble, row_number=2,
+                                             place=1, user_controlled=True, stroke=BACKSTROKE)
 
         self.assert_not_waiting_for_bell_time()
 
         self.assertEqual(0, self.wait_rhythm.delay)
+
+        self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, HANDSTROKE, 1)
+        self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, BACKSTROKE, 1.1)
 
     def test_wait_for_bell_time__bell_early_and_corrected_in_previous_row_waits_for_bell(self):
         # Arrange
         expected_first_time = 1
         expected_second_time = 2
 
-        self.wait_rhythm.expect_bell(treble, 1, 1, handstroke)
+        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE)
 
         # Treble rung by user
-        self.wait_rhythm.on_bell_ring(treble, handstroke, 1)
+        self.wait_rhythm.on_bell_ring(treble, HANDSTROKE, 1)
 
-        self.start_wait_for_bell_time_thread(current_time=expected_first_time, bell=treble, row_number=1, place=1,
-                                             user_controlled=True, stroke=handstroke)
+        self.start_wait_for_bell_time_thread(current_time=expected_first_time, bell=treble, row_number=1,
+                                             place=1, user_controlled=True, stroke=HANDSTROKE)
 
         # Treble accidentally rung by user and corrected back to the right stroke
-        self.wait_rhythm.on_bell_ring(treble, backstroke, 1.1)
-        self.wait_rhythm.on_bell_ring(treble, handstroke, 1.2)
+        self.wait_rhythm.on_bell_ring(treble, BACKSTROKE, 1.1)
+        self.wait_rhythm.on_bell_ring(treble, HANDSTROKE, 1.2)
 
         self.assert_not_waiting_for_bell_time()
 
-        self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, handstroke, 1)
-        self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, backstroke, 1.1)
-        self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, handstroke, 1.2)
+        self.wait_rhythm.expect_bell(treble, 2, 1, BACKSTROKE)
 
-        self.wait_rhythm.expect_bell(treble, 2, 1, backstroke)
-
-        self.start_wait_for_bell_time_thread(current_time=expected_second_time, bell=treble, row_number=2, place=1,
-                                             user_controlled=True, stroke=backstroke)
+        self.start_wait_for_bell_time_thread(current_time=expected_second_time, bell=treble, row_number=2,
+                                             place=1, user_controlled=True, stroke=BACKSTROKE)
 
         self.assertTrue(self.waiting_for_bell_time)
 
-        self.wait_rhythm.on_bell_ring(treble, backstroke, expected_second_time)
-        self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, backstroke, expected_second_time)
+        self.wait_rhythm.on_bell_ring(treble, BACKSTROKE, expected_second_time)
 
         self.assertEqual(0, self.wait_rhythm.delay)
+
+        self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, HANDSTROKE, 1)
+        self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, BACKSTROKE, 1.1)
+        self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, HANDSTROKE, 1.2)
+        self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, BACKSTROKE, expected_second_time)
 
 
 if __name__ == '__main__':

--- a/tests/test_wait_for_user_rhythm.py
+++ b/tests/test_wait_for_user_rhythm.py
@@ -2,11 +2,10 @@ import time
 import unittest
 from threading import Thread
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 from wheatley.bell import Bell
 from wheatley.rhythm import Rhythm, WaitForUserRhythm
-
 
 treble = Bell.from_number(1)
 second = Bell.from_number(2)
@@ -37,10 +36,12 @@ class WaitForUserRhythmTests(unittest.TestCase):
         self._return_from_sleep = False
         self._sleeping = False
 
-    def return_from_sleep(self, wait_for_sleep=True):
-        while wait_for_sleep and not self._sleeping or self._return_from_sleep:
-            time.sleep(0.001)
-        self._return_from_sleep = True
+    def return_from_sleep(self, seconds: float = 0.01, wait_for_sleep=True):
+        expected_sleeps = seconds / WaitForUserRhythm.sleep_time
+        for _ in range(round(expected_sleeps)):
+            while wait_for_sleep and not self._sleeping or self._return_from_sleep:
+                time.sleep(0.001)
+            self._return_from_sleep = True
 
     def start_wait_for_bell_time(self, current_time, bell, row_number, place, user_controlled, stroke):
         # Run on a different thread as it will loop until on_bell_ring called.
@@ -54,10 +55,12 @@ class WaitForUserRhythmTests(unittest.TestCase):
 
     def assert_not_waiting_for_bell_time(self):
         count = 0
+        time.sleep(0.01)
+
         while self.waiting_for_bell_time and count < 100:
             time.sleep(0.001)
             count += 1
-        self.assertFalse(self.waiting_for_bell_time)
+        self.assertFalse(self.waiting_for_bell_time, "Waiting for bell to ring")
 
     def test_on_bell_ring__no_initial_delay(self):
         self.wait_rhythm.expect_bell(treble, 1, 1, handstroke)
@@ -85,9 +88,7 @@ class WaitForUserRhythmTests(unittest.TestCase):
         self.start_wait_for_bell_time(current_time=expected_time, bell=treble, row_number=1, place=1,
                                       user_controlled=True, stroke=handstroke)
 
-        expected_sleeps = (actual_time - expected_time)/WaitForUserRhythm.sleep_time
-        for _ in range(round(expected_sleeps)):
-            self.return_from_sleep()
+        self.return_from_sleep(seconds=actual_time - expected_time)
 
         self.wait_rhythm.on_bell_ring(treble, handstroke, actual_time)
         self.return_from_sleep(wait_for_sleep=False)
@@ -97,6 +98,97 @@ class WaitForUserRhythmTests(unittest.TestCase):
         self.mock_inner_rhythm.on_bell_ring.assert_called_once_with(treble, handstroke, actual_time - initial_delay)
         # 10 + (11.1 - 11) = 10.1
         self.assertEqual(10.1, round(self.wait_rhythm.delay, 2))
+
+    def test_wait_for_bell_time__bell_rung_early_in_row(self):
+        initial_delay = 0
+        expected_first_bell_time = 1
+        expected_second_bell_time = 2
+
+        self.wait_rhythm.expect_bell(treble, 1, 1, handstroke)
+        self.wait_rhythm.expect_bell(second, 1, 2, handstroke)
+        self.wait_rhythm.delay = initial_delay
+
+        self.start_wait_for_bell_time(current_time=expected_first_bell_time, bell=treble, row_number=1, place=1,
+                                      user_controlled=True, stroke=handstroke)
+
+        self.return_from_sleep(seconds=0.1)
+
+        self.wait_rhythm.on_bell_ring(second, handstroke, 1.1)
+
+        self.return_from_sleep(seconds=0.1)
+        self.assertTrue(self.waiting_for_bell_time)
+        self.wait_rhythm.on_bell_ring(treble, handstroke, 1.2)
+        self.return_from_sleep(wait_for_sleep=False)
+        self.assert_not_waiting_for_bell_time()
+        self.start_wait_for_bell_time(current_time=expected_second_bell_time, bell=second, row_number=1, place=1,
+                                      user_controlled=True, stroke=handstroke)
+        self.assert_not_waiting_for_bell_time()
+
+        self.mock_inner_rhythm.on_bell_ring.assert_any_call(second, handstroke, 1.1)
+        self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, handstroke, 1.2)
+        # 1.2 - 1, Second being early has not added delay
+        self.assertEqual(0.2, round(self.wait_rhythm.delay, 2))
+
+    def test_wait_for_bell_time__bell_rung_early_in_previous_row(self):
+        initial_delay = 0
+        expected_first_time = 1
+        expected_second_time = 2
+
+        self.wait_rhythm.expect_bell(treble, 1, 1, handstroke)
+        self.wait_rhythm.delay = initial_delay
+
+        self.wait_rhythm.on_bell_ring(treble, handstroke, 1)
+
+        self.start_wait_for_bell_time(current_time=expected_first_time, bell=treble, row_number=1, place=1,
+                                      user_controlled=True, stroke=handstroke)
+
+        self.wait_rhythm.on_bell_ring(treble, backstroke, 1.1)
+
+        self.return_from_sleep(wait_for_sleep=False)
+        self.assert_not_waiting_for_bell_time()
+
+        self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, handstroke, 1)
+        self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, backstroke, 1.1)
+
+        self.wait_rhythm.expect_bell(treble, 2, 1, backstroke)
+
+        self.start_wait_for_bell_time(current_time=expected_second_time, bell=treble, row_number=2, place=1,
+                                      user_controlled=True, stroke=backstroke)
+
+        self.assert_not_waiting_for_bell_time()
+
+        self.assertEqual(0, self.wait_rhythm.delay)
+
+    def test_wait_for_bell_time__bell_early_and_corrected_in_previous_row(self):
+        initial_delay = 0
+        expected_first_time = 1
+        expected_second_time = 2
+
+        self.wait_rhythm.expect_bell(treble, 1, 1, handstroke)
+        self.wait_rhythm.delay = initial_delay
+
+        self.wait_rhythm.on_bell_ring(treble, handstroke, 1)
+
+        self.start_wait_for_bell_time(current_time=expected_first_time, bell=treble, row_number=1, place=1,
+                                      user_controlled=True, stroke=handstroke)
+
+        self.wait_rhythm.on_bell_ring(treble, backstroke, 1.1)
+        self.wait_rhythm.on_bell_ring(treble, handstroke, 1.2)
+
+        self.return_from_sleep(wait_for_sleep=False)
+        self.assert_not_waiting_for_bell_time()
+
+        self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, handstroke, 1)
+        self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, backstroke, 1.1)
+        self.mock_inner_rhythm.on_bell_ring.assert_any_call(treble, handstroke, 1.2)
+
+        self.wait_rhythm.expect_bell(treble, 2, 1, backstroke)
+
+        self.start_wait_for_bell_time(current_time=expected_second_time, bell=treble, row_number=2, place=1,
+                                      user_controlled=True, stroke=backstroke)
+
+        self.assertTrue(self.waiting_for_bell_time)
+        self.assertEqual(0, self.wait_rhythm.delay)
 
 
 if __name__ == '__main__':

--- a/wheatley/rhythm.py
+++ b/wheatley/rhythm.py
@@ -11,6 +11,7 @@ from abc import ABCMeta, abstractmethod
 
 from wheatley.bell import Bell
 from wheatley.regression import calculate_regression
+from wheatley.tower import HANDSTROKE, BACKSTROKE
 
 WEIGHT_REJECTION_THRESHOLD = 0.001
 
@@ -89,9 +90,9 @@ class WaitForUserRhythm(Rhythm):
         """
 
         self._inner_rhythm = rhythm
-        self._current_stroke = True
-        self._expected_bells = {True: set(), False: set()}
-        self._early_bells = {True: set(), False: set()}
+        self._current_stroke = HANDSTROKE
+        self._expected_bells = {HANDSTROKE: set(), BACKSTROKE: set()}
+        self._early_bells = {HANDSTROKE: set(), BACKSTROKE: set()}
         self.delay = 0
         self.logger = logging.getLogger(self.logger_name)
 

--- a/wheatley/tower.py
+++ b/wheatley/tower.py
@@ -11,6 +11,9 @@ import socketio
 
 from wheatley.bell import Bell
 
+HANDSTROKE = True
+BACKSTROKE = False
+
 
 class RingingRoomTower:
     """ A class representing a tower, which will handle a single ringing-room session. """
@@ -18,7 +21,7 @@ class RingingRoomTower:
     logger_name = "TOWER"
 
     def __init__(self, tower_id: int, url: str):
-        """ Initilise a tower with a given room id and url. """
+        """ Initialise a tower with a given room id and url. """
 
         self.tower_id = tower_id
         self.logger = logging.getLogger(self.logger_name)
@@ -221,4 +224,4 @@ class RingingRoomTower:
     def _bells_set_at_hand(number: int):
         """ Returns the representation of `number` bells, all set at handstroke. """
 
-        return [True for _ in range(number)]
+        return [HANDSTROKE for _ in range(number)]


### PR DESCRIPTION
A draft of capturing when a bell is rung onto the opposite stroke in the previous row, just wait for the inner rhythm time.

When it is rung back onto the correct stroke before the row starts it will be still be waited for. I'm sure there are  possibilities to get in a muddle still, e.g. perhaps trying to get back on the correct stroke after the current row has started.

Testing this is a bit complicated and needs some tidying up still.

Fixes #53 