### PR TITLE
Suppress or fix linter errors, and reformat the code

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,11 +17,10 @@ jobs:
       - uses: actions/checkout@v1
       - name: Install dependencies
         run: |
-          sudo apt-get install pylint3
           pip3 install -r requirements.txt
-          pip3 install pytest
+          pip3 install pytest pylint
       - name: Run linter
-        run: pylint3 wheatley/**/*.py
+        run: python3 -m pylint wheatley/**/*.py
       - name: Run tests
         run: python3 -m pytest
       - name: Run fuzzer

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install -r requirements.txt
-          pip3 install pytest pylint
+          pip3 install setuptools pytest pylint
       - name: Run linter
         run: python3 -m pylint wheatley/**/*.py
       - name: Run tests

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -21,11 +21,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine pytest
+        pip install setuptools wheel twine pytest pylint
         pip install -r requirements.txt
-        sudo apt-get install pylint3
     - name: Run linter
-      run: pylint3 wheatley/**/*.py
+      run: python -m pylint wheatley/**/*.py
     - name: Run tests
       run: python -m pytest
     - name: Run fuzzer

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,10 +1,10 @@
 [MESSAGES CONTROL]
 
-disable=broad-except,len-as-condition
+disable=broad-except,len-as-condition,logging-fstring-interpolation,unnecessary-pass
 
 [FORMAT]
 
-# Just allow me to make one-letter variable names
+# Just allow me to make one-letter variable names, please!
 good-names=a,b,c,d,e,f,g,h,i,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z
 
 # Enforce Unix line endings

--- a/wheatley/bot.py
+++ b/wheatley/bot.py
@@ -179,6 +179,7 @@ into changes unless something is done!")
 
         assert self.row_generator.number_of_bells == self._tower.number_of_bells, \
             f"{self.row_generator.number_of_bells} != {self._tower.number_of_bells}"
+
         self.row_generator.reset()
         self.start_next_row()
 

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -19,7 +19,8 @@ from wheatley.arg_parsing import parse_peal_speed, PealSpeedParseError, parse_ca
 from wheatley.row_generation import RowGenerator, ComplibCompositionGenerator
 from wheatley.row_generation import MethodPlaceNotationGenerator
 from wheatley.row_generation.complib_composition_generator import PrivateCompError, InvalidCompError
-from wheatley.row_generation.method_place_notation_generator import MethodNotFoundError, generator_from_special_title
+from wheatley.row_generation.method_place_notation_generator import MethodNotFoundError, \
+                                                                    generator_from_special_title
 
 
 def row_generator(args):

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -199,7 +199,6 @@ def main():
         type=str,
         help="The title of the method you want to ring"
     )
-
     parser.add_argument(
         "-b",
         "--bob",

--- a/wheatley/page_parser.py
+++ b/wheatley/page_parser.py
@@ -13,6 +13,7 @@ class TowerNotFoundError(ValueError):
 
     def __init__(self, tower_id, url):
         super().__init__()
+
         self._id = tower_id
         self._url = url
 
@@ -24,6 +25,7 @@ class InvalidURLError(Exception):
 
     def __init__(self, url):
         super().__init__()
+
         self._url = url
 
     def __str__(self):

--- a/wheatley/rhythm.py
+++ b/wheatley/rhythm.py
@@ -72,7 +72,7 @@ class Rhythm(metaclass=ABCMeta):
 
         pass
 
-    def sleep(self, seconds: float):
+    def sleep(self, seconds: float):  # pylint: disable=no-self-use
         """ Sleeps for given number of seconds. Allows mocking in tests"""
         time.sleep(seconds)
 
@@ -229,10 +229,10 @@ class RegressionRhythm(Rhythm):
         """ Sleeps the thread until a given Bell should have rung. """
 
         if user_controlled and self._start_time == float('inf'):
-            self.logger.debug(f"Waiting for pull off")
+            self.logger.debug("Waiting for pull off")
             while self._start_time == float('inf'):
                 self.sleep(0.01)
-            self.logger.debug(f"Pulled off")
+            self.logger.debug("Pulled off")
             return
 
         bell_time = self.index_to_real_time(row_number, place)

--- a/wheatley/rhythm.py
+++ b/wheatley/rhythm.py
@@ -74,6 +74,7 @@ class Rhythm(metaclass=ABCMeta):
 
     def sleep(self, seconds: float):  # pylint: disable=no-self-use
         """ Sleeps for given number of seconds. Allows mocking in tests"""
+
         time.sleep(seconds)
 
 
@@ -105,10 +106,12 @@ class WaitForUserRhythm(Rhythm):
                                               user_controlled, stroke)
         if user_controlled:
             delay_for_user = 0
+
             while bell in self._expected_bells[stroke]:
                 self.sleep(self.sleep_time)
                 delay_for_user += self.sleep_time
                 self.logger.debug(f"Waiting for {bell}")
+
             if delay_for_user:
                 self.logger.info(f"Delayed for {delay_for_user}")
                 self.delay += delay_for_user
@@ -142,6 +145,7 @@ class WaitForUserRhythm(Rhythm):
                 self._expected_bells[self._current_stroke].remove(bell)
             except KeyError:
                 pass
+
             try:
                 self._early_bells[not self._current_stroke].remove(bell)
             except KeyError:
@@ -230,12 +234,16 @@ class RegressionRhythm(Rhythm):
 
         if user_controlled and self._start_time == float('inf'):
             self.logger.debug("Waiting for pull off")
+
             while self._start_time == float('inf'):
                 self.sleep(0.01)
+
             self.logger.debug("Pulled off")
+
             return
 
         bell_time = self.index_to_real_time(row_number, place)
+
         if bell_time == float('inf') or self._start_time == 0:
             self.logger.error(f"Bell Time {bell_time}; Start Time {self._start_time}")
             self.sleep(self._blow_interval or 0.2)

--- a/wheatley/row_generation/complib_composition_generator.py
+++ b/wheatley/row_generation/complib_composition_generator.py
@@ -54,9 +54,11 @@ class ComplibCompositionGenerator(RowGenerator):
         self.loaded_rows = [[Bell.from_str(bell) for bell in row] for row in split_rows]
 
         stage = len(self.loaded_rows[0])
+
         super().__init__(stage)
 
     def _gen_row(self, previous_row: List[Bell], is_handstroke: bool, index: int) -> List[Bell]:
         if index < len(self.loaded_rows):
             return self.loaded_rows[index]
+
         return self.rounds()

--- a/wheatley/row_generation/dixonoids_generator.py
+++ b/wheatley/row_generation/dixonoids_generator.py
@@ -35,16 +35,9 @@ class DixonoidsGenerator(RowGenerator):
 
         super(DixonoidsGenerator, self).__init__(stage)
 
-        if plain_rules is None:
-            plain_rules = self.DixonsRules
-        if bob_rules is None:
-            bob_rules = self.DefaultBob
-        if single_rules is None:
-            single_rules = self.DefaultSingle
-
-        self.plain_rules = self._convert_pn_dict(plain_rules)
-        self.bob_rules = self._convert_pn_dict(bob_rules)
-        self.single_rules = self._convert_pn_dict(single_rules)
+        self.plain_rules = self._convert_pn_dict(plain_rules or self.DixonsRules)
+        self.bob_rules = self._convert_pn_dict(bob_rules or self.DefaultBob)
+        self.single_rules = self._convert_pn_dict(single_rules or self.DefaultSingle)
 
     def _gen_row(self, previous_row: List[Bell], is_handstroke: bool, index: int) -> List[Bell]:
         leading_bell = previous_row[0].number
@@ -52,10 +45,12 @@ class DixonoidsGenerator(RowGenerator):
 
         if self._has_bob and self.bob_rules.get(leading_bell):
             place_notation = self.bob_rules[leading_bell][pn_index]
+
             if not is_handstroke:
                 self.reset_calls()
         elif self._has_single and self.single_rules.get(leading_bell):
             place_notation = self.single_rules[leading_bell][pn_index]
+
             if not is_handstroke:
                 self.reset_calls()
         elif self.plain_rules.get(leading_bell):
@@ -63,8 +58,9 @@ class DixonoidsGenerator(RowGenerator):
         else:
             place_notation = self.plain_rules[0][pn_index]
 
-        row = self.permute(previous_row, place_notation)
-        return row
+        next_row = self.permute(previous_row, place_notation)
+
+        return next_row
 
     @staticmethod
     def _convert_pn_dict(rules: Dict[int, List[str]]) -> Dict[int, List[List[int]]]:

--- a/wheatley/row_generation/go_and_stop_calling_generator.py
+++ b/wheatley/row_generation/go_and_stop_calling_generator.py
@@ -17,6 +17,7 @@ class GoAndStopCallingGenerator(RowGenerator):
 
     def __init__(self, generator: RowGenerator, tower: RingingRoomTower):
         super().__init__(generator.stage)
+
         self.tower = tower
         self.generator = generator
         self.called_go = False
@@ -24,10 +25,12 @@ class GoAndStopCallingGenerator(RowGenerator):
     def next_row(self, is_handstroke: bool):
         if not self.called_go and not is_handstroke and random.choices([True, False], [1, 3]):
             self.tower.make_call(calls.GO)
+
         return super(GoAndStopCallingGenerator, self).next_row(is_handstroke)
 
     def _gen_row(self, previous_row: List[Bell], is_handstroke: bool, index: int) -> List[Bell]:
         next_row = self.generator._gen_row(previous_row, is_handstroke, index)
+
         if next_row == self.rounds():
             self.tower.make_call(calls.THATS_ALL)
 

--- a/wheatley/row_generation/helpers.py
+++ b/wheatley/row_generation/helpers.py
@@ -54,4 +54,5 @@ def convert_to_bell_string(bell: int) -> str:
 
     if bell <= 0 or bell >= len(_LOOKUP_NAME):
         raise ValueError(f"'{bell}' is not known bell number")
+
     return _LOOKUP_NAME[bell]

--- a/wheatley/row_generation/method_place_notation_generator.py
+++ b/wheatley/row_generation/method_place_notation_generator.py
@@ -33,7 +33,7 @@ def generator_from_special_title(method_title: str) -> Optional[RowGenerator]:
         return PlaceNotationGenerator.grandsire(stage)
     if method_name == "stedman" and stage % 2 and stage >= 5:
         return PlaceNotationGenerator.stedman(stage)
-    if method_name == "plain hunt" or method_name == "plain hunt on":
+    if method_name in ["plain hunt", "plain hunt on"]:
         return PlainHuntGenerator(stage)
     if method_name == "dixon's bob" and stage == 6:
         return DixonoidsGenerator(stage)
@@ -86,11 +86,10 @@ class MethodPlaceNotationGenerator(PlaceNotationGenerator):
             notation = symblock[0].text
             lead_end = symblock[1].text
             return f"&{notation},&{lead_end}", stage
-        elif len(block) != 0:
+        if len(block) != 0:
             notation = block[0].text
             return notation, stage
-        else:
-            raise Exception("Place notation not found")
+        raise Exception("Place notation not found")
 
     @staticmethod
     def _fetch_method(method_title):

--- a/wheatley/row_generation/method_place_notation_generator.py
+++ b/wheatley/row_generation/method_place_notation_generator.py
@@ -15,7 +15,9 @@ from .row_generator import RowGenerator
 
 def generator_from_special_title(method_title: str) -> Optional[RowGenerator]:
     """ Creates a row generator from special method titles. """
+
     lowered_title = method_title.lower().strip()
+
     if " " not in lowered_title:
         raise MethodNotFoundError(method_title)
 
@@ -31,12 +33,16 @@ def generator_from_special_title(method_title: str) -> Optional[RowGenerator]:
 
     if method_name == "grandsire" and stage >= 5:
         return PlaceNotationGenerator.grandsire(stage)
+
     if method_name == "stedman" and stage % 2 and stage >= 5:
         return PlaceNotationGenerator.stedman(stage)
+
     if method_name in ["plain hunt", "plain hunt on"]:
         return PlainHuntGenerator(stage)
+
     if method_name == "dixon's bob" and stage == 6:
         return DixonoidsGenerator(stage)
+
     return None
 
 
@@ -48,6 +54,7 @@ class MethodNotFoundError(ValueError):
 
     def __init__(self, name):
         super().__init__()
+
         self._name = name
 
     def __str__(self):
@@ -85,15 +92,21 @@ class MethodPlaceNotationGenerator(PlaceNotationGenerator):
         if len(symblock) != 0:
             notation = symblock[0].text
             lead_end = symblock[1].text
+
             return f"&{notation},&{lead_end}", stage
+
         if len(block) != 0:
             notation = block[0].text
+
             return notation, stage
+
         raise Exception("Place notation not found")
 
     @staticmethod
     def _fetch_method(method_title):
         params = {'title': method_title, 'fields': 'pn|stage'}
+
         source = requests.get('http://methods.ringing.org/cgi-bin/simple.pl', params=params)
         source.raise_for_status()
+
         return source.text

--- a/wheatley/row_generation/place_notation_generator.py
+++ b/wheatley/row_generation/place_notation_generator.py
@@ -19,6 +19,7 @@ class PlaceNotationGenerator(RowGenerator):
     def __init__(self, stage: int, method: str, bob: Dict[int, str] = None,
                  single: Dict[int, str] = None):
         super(PlaceNotationGenerator, self).__init__(stage)
+
         if bob is None:
             bob = PlaceNotationGenerator.DefaultBob
         if single is None:
@@ -50,6 +51,7 @@ class PlaceNotationGenerator(RowGenerator):
 
     def _gen_row(self, previous_row: List[Bell], is_handstroke: bool, index: int) -> List[Bell]:
         lead_index = index % self.lead_len
+
         assert lead_index % 2 != is_handstroke
 
         if self._has_bob and self.bobs_pn.get(lead_index):
@@ -79,6 +81,7 @@ class PlaceNotationGenerator(RowGenerator):
         main_body = ["1" if i % 2 else cross_notation for i in range(2 * stage)]
         main_body[0] = "3"
         notation = ".".join(main_body)
+
         return PlaceNotationGenerator(stage, notation, bob={-1: "3"}, single={-1: "3.123"})
 
     @staticmethod
@@ -95,6 +98,7 @@ class PlaceNotationGenerator(RowGenerator):
         stage_bell_2 = convert_to_bell_string(stage - 2)
 
         notation = f"3.1.{stage_bell}.3.1.3.1.3.{stage_bell}.1.3.1"
+
         return PlaceNotationGenerator(stage, notation, bob={3: stage_bell_2, 9: stage_bell_2},
                                       single={3: f"{stage_bell_2}{stage_bell_1}{stage_bell}",
                                               9: f"{stage_bell_2}{stage_bell_1}{stage_bell}"})
@@ -104,4 +108,5 @@ class PlaceNotationGenerator(RowGenerator):
         """ Generates Stedman on a given stage (even bell Stedman will cause an exception). """
 
         notation = "3.1.5.3.1.3.1.3.5.1.3.1"
+
         return PlaceNotationGenerator(5, notation, bob={}, single={6: "345", 12: "145"})

--- a/wheatley/row_generation/row_generator.py
+++ b/wheatley/row_generation/row_generator.py
@@ -87,6 +87,7 @@ class RowGenerator(metaclass=ABCMeta):
         """ Permute a row by a place notation given by `places`. """
 
         new_row = list(row)
+
         i = 1
         if places and places[0] % 2 == 0:
             # Skip 1 for implicit lead when lowest pn is even

--- a/wheatley/row_generation/row_generator.py
+++ b/wheatley/row_generation/row_generator.py
@@ -96,9 +96,9 @@ class RowGenerator(metaclass=ABCMeta):
             if i in places:
                 i += 1
                 continue
-            else:
-                # If not in place, must swap, index is 1 less than place
-                new_row[i - 1], new_row[i] = new_row[i], new_row[i - 1]
-                i += 2
+
+            # If not in place, must swap, index is 1 less than place
+            new_row[i - 1], new_row[i] = new_row[i], new_row[i - 1]
+            i += 2
 
         return new_row

--- a/wheatley/tower.py
+++ b/wheatley/tower.py
@@ -39,9 +39,12 @@ class RingingRoomTower:
         """ Called when entering a 'with' block.  Opens the socket-io connection. """
 
         self.logger.debug("ENTER")
+
         if self._socket_io_client is not None:
             raise Exception("Trying to connect twice")
+
         self._create_client()
+
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -66,17 +69,22 @@ class RingingRoomTower:
 
         try:
             stroke = self.get_stroke(bell)
+
             if stroke != handstroke:
                 self.logger.error(f"Bell {bell} on opposite stroke")
+
                 return False
+
             self._emit(
                 "c_bell_rung",
                 {"bell": bell.number, "stroke": stroke, "tower_id": self.tower_id},
                 ""
             )
+
             return True
         except Exception as e:
             self.logger.error(e)
+
             return False
 
     def user_controlled(self, bell: Bell):
@@ -89,7 +97,9 @@ class RingingRoomTower:
 
         if bell.index >= len(self._bell_state) or bell.index < 0:
             self.logger.error(f"Bell {bell} not in tower")
+
             return None
+
         return self._bell_state[bell.index]
 
     def make_call(self, call: str):
@@ -116,12 +126,16 @@ class RingingRoomTower:
 
         if self._socket_io_client is None:
             raise Exception("Not Connected")
+
         iteration = 0
+
         while not self._bell_state:
             iteration += 1
+
             if iteration % 50 == 0:
                 self._join_tower()
                 self._request_global_state()
+
             sleep(0.1)
 
     def _create_client(self):
@@ -171,6 +185,7 @@ class RingingRoomTower:
         self._on_global_bell_state(data)
 
         who_rang = Bell.from_number(data["who_rang"])
+
         for bell_ring_callback in self.invoke_on_bell_rung:
             bell_ring_callback(who_rang, self.get_stroke(who_rang))
 
@@ -192,10 +207,12 @@ class RingingRoomTower:
         """ Callback called when the number of bells in the room changes. """
 
         new_size = data["size"]
+
         if new_size != self.number_of_bells:
             self._assigned_users = {}
             self._bell_state = self._bells_set_at_hand(new_size)
             self.logger.info(f"RECEIVED: New tower size '{new_size}'")
+
             for invoke_callback in self.invoke_on_reset:
                 invoke_callback()
 
@@ -216,7 +233,9 @@ class RingingRoomTower:
         found_callback = False
         for call_callback in self.invoke_on_call.get(call, []):
             call_callback()
+
             found_callback = True
+
         if not found_callback:
             self.logger.warning(f"No callback found for '{call}'")
 


### PR DESCRIPTION
The CI action that runs pylint is running an old version of pylint - and the new one has added new lints and strengthened some old ones.  So I've fixed or suppressed all the errors caused by that, and now we'll be able to use the latest pylint version.

I've also taken the opportunity to make all the code consistently spaced out - enforcing things like always putting a blank line after docstrings and before `return`s/`continue`s/`break`s that pylint won't check.