### PR TITLE
Re-add `--wait` flag with deprecation warning

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,5 +1,6 @@
 # 0.3.1
 - Hopefully fixed issue of Wheatley hanging forever when `Stand next` is called.
+- Re-add `--wait` flag, which does nothing but shows deprecation warning when used.
 - Renamed `BOT` to `[WHEATLEY]` in the logging output for unassigned bells
 
 # 0.3.0

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -151,6 +151,12 @@ def main():
               rhythm."
     )
     parser.add_argument(
+        "-w", "--wait",
+        action="store_true",
+        help="Legacy parameter, which is now set by default. The previous default behaviour of not waiting \
+              can be set with '-k'/'--keep-going'."
+    )
+    parser.add_argument(
         "-I", "--inertia",
         type=float,
         default=0.5,
@@ -222,6 +228,9 @@ def main():
     )
 
     args = parser.parse_args()
+
+    if args.wait:
+        print("Deprecation warning: `--wait` has been replaced with `--keep-going`!")
 
     # Run the program
     configure_logging()


### PR DESCRIPTION
When helping people out with bugs in Wheatley, I noticed that _removing_ a CLI arg is a pretty bad plan since I had to try and say `if you're on >=0.3.0, do not use '--wait' because it is set by default and will crash Wheatley - but if you are on <0.3.0, then you should set '--wait'`.  This is a bit of a nightmare, and so it would be a lot better to re-add `--wait`, but have it do nothing and emit a deprecation warning.