### PR TITLE
Remove duplicate short argument -n

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -3,7 +3,7 @@
   Wheatley is ringing most of the bells.
 - Group CLI args into groups for better readability of both code and help messages.
 - Overhaul help and debug messages to use `Wheatley` rather than `bot`.
-- Added CLI arg (`-n` or `--name`) to tell Wheatley to ring bells assigned to a specific person.
+- Added CLI arg `--name` to tell Wheatley to ring bells assigned to a specific person.
 
 # 0.3.1
 - Hopefully fixed issue of Wheatley hanging forever when `Stand next` is called.

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -123,7 +123,7 @@ def main():
         help="The URL of the server to join (defaults to 'https://ringingroom.com')"
     )
     tower_group.add_argument(
-        "-n", "--name",
+        "--name",
         default=None,
         type=str,
         help="If set, then the bot will ring bells assigned to the given name. \


### PR DESCRIPTION
Already used for `--single`