### PR TITLE
Fix or supress stronger linter errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,11 +19,10 @@ jobs:
       - uses: actions/checkout@v1
       - name: Install dependencies
         run: |
-          sudo apt-get install pylint3
+          pip3 install setuptools
           pip3 install -r requirements.txt
-          pip3 install pytest
       - name: Run linter
-        run: pylint3 wheatley/**/*.py
+        run: python3 -m pylint wheatley/**/*.py
       - name: Run unit tests
         run: python3 -m pytest
       - name: Run integration tests

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -21,11 +21,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine pytest
+        pip install setuptools wheel twine
         pip install -r requirements.txt
-        sudo apt-get install pylint3
     - name: Run linter
-      run: pylint3 wheatley/**/*.py
+      run: python -m pylint wheatley/**/*.py
     - name: Run tests
       run: python -m pytest
     - name: Run fuzzer

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,6 @@
 [MESSAGES CONTROL]
 
-disable=broad-except,len-as-condition
+disable=broad-except,len-as-condition,logging-fstring-interpolation
 
 [FORMAT]
 
@@ -16,4 +16,5 @@ max-line-length=110
 
 max-args=10
 max-attributes=20
-max-branches = 15
+max-branches=15
+max-locals=20

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ certifi==2020.4.5.2
 chardet==3.0.4
 idna==2.9
 numpy==1.18.5
+pylint==2.6.0
+pytest==5.4.3
 python-engineio==3.13.0
 python-socketio==4.6.0
 requests==2.24.0

--- a/wheatley/bell.py
+++ b/wheatley/bell.py
@@ -15,8 +15,8 @@ class Bell:
         """
         try:
             index = Bell._lookup_name.index(bell_str)
-        except ValueError:
-            raise ValueError(f"'{bell_str}' is not known bell symbol")
+        except ValueError as e:
+            raise ValueError(f"'{bell_str}' is not known bell symbol") from e
 
         return cls(index)
 

--- a/wheatley/page_parser.py
+++ b/wheatley/page_parser.py
@@ -55,8 +55,8 @@ def get_load_balancing_url(tower_id, unfixed_http_server_url):
 
     try:
         html = requests.get(url).text
-    except requests.exceptions.ConnectionError:
-        raise InvalidURLError(http_server_url)
+    except requests.exceptions.ConnectionError as e:
+        raise InvalidURLError(http_server_url) from e
 
     try:
         url_start_index = html.index("server_ip") + len('server_ip: "')
@@ -64,5 +64,5 @@ def get_load_balancing_url(tower_id, unfixed_http_server_url):
         load_balancing_url = string_that_starts_with_url[:string_that_starts_with_url.index('"')]
 
         return load_balancing_url
-    except ValueError:
-        raise TowerNotFoundError(tower_id, http_server_url)
+    except ValueError as e:
+        raise TowerNotFoundError(tower_id, http_server_url) from e

--- a/wheatley/rhythm.py
+++ b/wheatley/rhythm.py
@@ -8,10 +8,12 @@ import math
 import time
 
 from abc import ABCMeta, abstractmethod
+from typing import Any
 
 from wheatley.bell import Bell
 from wheatley.regression import calculate_regression
 from wheatley.tower import HANDSTROKE, BACKSTROKE, stroke_to_string
+
 
 WEIGHT_REJECTION_THRESHOLD = 0.001
 
@@ -41,7 +43,6 @@ class Rhythm(metaclass=ABCMeta):
     def wait_for_bell_time(self, current_time: float, bell: Bell, row_number: int, place: int,
                            user_controlled: bool, stroke: bool):
         """ Sleeps the thread until a given Bell should have rung. """
-        pass
 
     @abstractmethod
     def expect_bell(self, expected_bell: Bell, row_number: int, place: int, expected_stroke: bool):
@@ -51,22 +52,19 @@ class Rhythm(metaclass=ABCMeta):
         _should_ have been in the ringing, and so can use that knowledge to inform the speed of the
         ringing.
         """
-        pass
 
     @abstractmethod
     def on_bell_ring(self, bell: Bell, stroke: bool, real_time: float):
         """
         Called when a bell is rung at a given stroke.  Used as a callback from the Tower class.
         """
-        pass
 
     @abstractmethod
     def initialise_line(self, stage: int, user_controls_treble: bool, start_time: float,
                         number_of_user_controlled_bells: int):
         """ Allow the Rhythm object to initialise itself when 'Look to' is called. """
-        pass
 
-    def sleep(self, seconds: float):
+    def sleep(self, seconds: float): #  pylint: disable=no-self-use
         """ Sleeps for given number of seconds. Allows mocking in tests"""
         time.sleep(seconds)
 
@@ -238,12 +236,12 @@ class RegressionRhythm(Rhythm):
     def wait_for_bell_time(self, current_time, bell, row_number, place, user_controlled, stroke):
         """ Sleeps the thread until a given Bell should have rung. """
         if user_controlled and self._start_time == float('inf'):
-            self.logger.debug(f"Waiting for pull off")
+            self.logger.debug("Waiting for pull off")
 
             while self._start_time == float('inf'):
                 self.sleep(0.01)
 
-            self.logger.debug(f"Pulled off")
+            self.logger.debug("Pulled off")
 
             return
 

--- a/wheatley/row_generation/dixonoids_generator.py
+++ b/wheatley/row_generation/dixonoids_generator.py
@@ -32,7 +32,7 @@ class DixonoidsGenerator(RowGenerator):
         :param single_rules: Dictionary of leading bell: [handstroke pn, backstroke pn]
                           Only include bells which lead when a single is rung
         """
-        super(DixonoidsGenerator, self).__init__(stage)
+        super().__init__(stage)
 
         if plain_rules is None:
             plain_rules = self.DixonsRules

--- a/wheatley/row_generation/go_and_stop_calling_generator.py
+++ b/wheatley/row_generation/go_and_stop_calling_generator.py
@@ -26,7 +26,7 @@ class GoAndStopCallingGenerator(RowGenerator):
         if not self.called_go and not is_handstroke and random.choices([True, False], [1, 3]):
             self.tower.make_call(calls.GO)
 
-        return super(GoAndStopCallingGenerator, self).next_row(is_handstroke)
+        return super().next_row(is_handstroke)
 
     def _gen_row(self, previous_row: List[Bell], is_handstroke: bool, index: int) -> List[Bell]:
         next_row = self.generator._gen_row(previous_row, is_handstroke, index)

--- a/wheatley/row_generation/helpers.py
+++ b/wheatley/row_generation/helpers.py
@@ -44,8 +44,8 @@ def convert_bell_string(bell: str) -> int:
     """ Convert a single-char string representing a bell into an integer. """
     try:
         return _LOOKUP_NAME.index(bell)
-    except ValueError:
-        raise ValueError(f"'{bell}' is not known bell symbol")
+    except ValueError as e:
+        raise ValueError(f"'{bell}' is not known bell symbol") from e
 
 
 def convert_to_bell_string(bell: int) -> str:

--- a/wheatley/row_generation/method_place_notation_generator.py
+++ b/wheatley/row_generation/method_place_notation_generator.py
@@ -33,7 +33,7 @@ def generator_from_special_title(method_title: str) -> Optional[RowGenerator]:
         return PlaceNotationGenerator.grandsire(stage)
     if method_name == "stedman" and stage % 2 and stage >= 5:
         return PlaceNotationGenerator.stedman(stage)
-    if method_name == "plain hunt" or method_name == "plain hunt on":
+    if method_name in ["plain hunt", "plain hunt on"]:
         return PlainHuntGenerator(stage)
     if method_name == "dixon's bob" and stage == 6:
         return DixonoidsGenerator(stage)
@@ -63,10 +63,10 @@ class MethodPlaceNotationGenerator(PlaceNotationGenerator):
 
         try:
             method_pn, stage = self._parse_xml(method_xml)
-        except AttributeError:
-            raise MethodNotFoundError(method_title)
+        except AttributeError as e:
+            raise MethodNotFoundError(method_title) from e
 
-        super(MethodPlaceNotationGenerator, self).__init__(
+        super().__init__(
             stage,
             method_pn,
             bob,
@@ -88,12 +88,13 @@ class MethodPlaceNotationGenerator(PlaceNotationGenerator):
             lead_end = symblock[1].text
 
             return f"&{notation},&{lead_end}", stage
-        elif len(block) != 0:
+
+        if len(block) != 0:
             notation = block[0].text
 
             return notation, stage
-        else:
-            raise Exception("Place notation not found")
+
+        raise Exception("Place notation not found")
 
     @staticmethod
     def _fetch_method(method_title):

--- a/wheatley/row_generation/place_notation_generator.py
+++ b/wheatley/row_generation/place_notation_generator.py
@@ -18,7 +18,7 @@ class PlaceNotationGenerator(RowGenerator):
 
     def __init__(self, stage: int, method: str, bob: Dict[int, str] = None,
                  single: Dict[int, str] = None):
-        super(PlaceNotationGenerator, self).__init__(stage)
+        super().__init__(stage)
 
         if bob is None:
             bob = PlaceNotationGenerator.DefaultBob

--- a/wheatley/row_generation/row_generator.py
+++ b/wheatley/row_generation/row_generator.py
@@ -89,9 +89,9 @@ class RowGenerator(metaclass=ABCMeta):
             if i in places:
                 i += 1
                 continue
-            else:
-                # If not in place, must swap, index is 1 less than place
-                new_row[i - 1], new_row[i] = new_row[i], new_row[i - 1]
-                i += 2
+
+            # If not in place, must swap, index is 1 less than place
+            new_row[i - 1], new_row[i] = new_row[i], new_row[i - 1]
+            i += 2
 
         return new_row


### PR DESCRIPTION
I had to update `pylint` on my laptop, and it suddenly added a whole bunch of extra lints that our code apparently didn't follow.

So I've either fixed them or suppressed the lints if I think they're not useful.