### PR TITLE
Update Wheatley to assign users by IDs not names

### DIFF
--- a/wheatley/tower.py
+++ b/wheatley/tower.py
@@ -97,9 +97,10 @@ class RingingRoomTower:
 
     def user_name_from_id(self, user_id: int) -> str:
         """
-        Converts a numerical user ID into the corresponding user name, throwing a KeyError if not found.
+        Converts a numerical user ID into the corresponding user name, returning None if user_id is not in
+        the tower.
         """
-        return self._user_list[user_id]
+        return self._user_list.get(user_id)
 
     def get_stroke(self, bell: Bell):
         """ Returns the stroke of a given bell. """

--- a/wheatley/tower.py
+++ b/wheatley/tower.py
@@ -31,6 +31,8 @@ class RingingRoomTower:
 
         self._bell_state = []
         self._assigned_users = {}
+        # A map from user IDs to the corresponding user name
+        self._user_list: Dict[int, str] = {}
 
         self.invoke_on_call: Dict[str, List[Callable[[], Any]]] = collections.defaultdict(list)
         self.invoke_on_reset: List[Callable[[], Any]] = []
@@ -86,9 +88,27 @@ class RingingRoomTower:
             self.logger.error(e)
             return False
 
-    def is_bell_assigned_to(self, bell: Bell, user: Optional[str]):
+    def is_bell_assigned_to(self, bell: Bell, user_name: Optional[str]):
         """ Returns true if a given bell is assigned to the given user name. """
-        return self._assigned_users.get(bell, None) == user
+        try:
+            return self.user_name_from_id(self._assigned_users.get(bell, None)) == user_name
+        except KeyError:
+            return False
+
+    def user_name_from_id(self, user_id: int) -> str:
+        """
+        Converts a numerical user ID into the corresponding user name, throwing a KeyError if not found.
+        """
+        return self._user_list[user_id]
+
+    def user_id_from_name(self, user_name: int) -> str:
+        """
+        Converts a numerical user ID into the corresponding user name, throwing a KeyError if not found.
+        """
+        for u_id, name in self._user_list:
+            if name == user_name:
+                return u_id
+        raise KeyError(f"No user ID found corresponding to {user_name}")
 
     def get_stroke(self, bell: Bell):
         """ Returns the stroke of a given bell. """
@@ -133,30 +153,55 @@ class RingingRoomTower:
         self._socket_io_client = socketio.Client()
         self._socket_io_client.connect(self._url)
         self.logger.info(f"Connected to {self._url}")
-        self._join_tower()
 
         self._socket_io_client.on("s_bell_rung", self._on_bell_rung)
         self._socket_io_client.on("s_global_state", self._on_global_bell_state)
+        self._socket_io_client.on("s_user_entered", self._on_user_entered)
+        self._socket_io_client.on("s_set_userlist", self._on_user_list)
         self._socket_io_client.on("s_size_change", self._on_size_change)
         self._socket_io_client.on("s_assign_user", self._on_assign_user)
         self._socket_io_client.on("s_call", self._on_call)
         self._socket_io_client.on("s_user_left", self._on_user_leave)
 
+        self._join_tower()
         self._request_global_state()
 
     def _on_user_leave(self, data):
-        user_that_left = data["user_name"]
+        user_id_that_left = data["user_id"]
+        user_name_that_left = data["username"]
+
+        # Remove the user ID that left from our user list
+        if user_id_that_left not in self._user_list:
+            self.logger.warning(
+                f"User #{user_id_that_left}:'{user_name_that_left}' left, but wasn't in the user list."
+            )
+        elif self._user_list[user_id_that_left] != data['username']:
+            self.logger.warning(f"User #{user_id_that_left}:'{user_name_that_left}' left, but that ID was \
+logged in as '{self._user_list[user_id_that_left]}'.")
+            del self._user_list[user_id_that_left]
 
         bells_unassigned = []
 
         # Unassign all instances of that user
         for bell, user in self._assigned_users.items():
-            if user == user_that_left:
+            if user == user_id_that_left:
                 self._assigned_users[bell] = None
 
-                bells_unassigned.append(str(bell))
+                bells_unassigned.append(bell)
 
-        self.logger.info(f"RECEIVED: User {user_that_left} left from bells {bells_unassigned}.")
+        self.logger.info(
+            f"RECEIVED: User #{user_id_that_left}:'{user_name_that_left}' left from bells {bells_unassigned}."
+        )
+
+    def _on_user_entered(self, data):
+        """ Called when the server receives a uew user so we can update our user list. """
+        # Add the new user to the user list, so we can match up their ID with their username
+        self._user_list[data['user_id']] = data['username']
+
+    def _on_user_list(self, user_list):
+        """ Called when the server broadcasts a user list when Wheatley joins a tower. """
+        for user in user_list['user_list']:
+            self._user_list[user['user_id']] = user['username']
 
     def _join_tower(self):
         """ Joins the tower as an anonymous user. """
@@ -219,7 +264,7 @@ class RingingRoomTower:
         self._assigned_users[bell] = user
 
         if user:
-            self.logger.info(f"RECEIVED: Assigned bell '{bell}' to '{user or '[WHEATLEY]'}'")
+            self.logger.info(f"RECEIVED: Assigned bell '{bell}' to '{self.user_name_from_id(user)}'")
         else:
             self.logger.info(f"RECEIVED: Unassigned bell '{bell}'")
 

--- a/wheatley/tower.py
+++ b/wheatley/tower.py
@@ -32,7 +32,7 @@ class RingingRoomTower:
         self._bell_state = []
         self._assigned_users = {}
         # A map from user IDs to the corresponding user name
-        self._user_list: Dict[int, str] = {}
+        self._user_name_map: Dict[int, str] = {}
 
         self.invoke_on_call: Dict[str, List[Callable[[], Any]]] = collections.defaultdict(list)
         self.invoke_on_reset: List[Callable[[], Any]] = []
@@ -103,7 +103,7 @@ class RingingRoomTower:
         Converts a numerical user ID into the corresponding user name, returning None if user_id is not in
         the tower.
         """
-        return self._user_list.get(user_id)
+        return self._user_name_map.get(user_id)
 
     def get_stroke(self, bell: Bell):
         """ Returns the stroke of a given bell. """
@@ -166,14 +166,14 @@ class RingingRoomTower:
         user_name_that_left = data["username"]
 
         # Remove the user ID that left from our user list
-        if user_id_that_left not in self._user_list:
+        if user_id_that_left not in self._user_name_map:
             self.logger.warning(
                 f"User #{user_id_that_left}:'{user_name_that_left}' left, but wasn't in the user list."
             )
-        elif self._user_list[user_id_that_left] != data['username']:
+        elif self._user_name_map[user_id_that_left] != data['username']:
             self.logger.warning(f"User #{user_id_that_left}:'{user_name_that_left}' left, but that ID was \
-logged in as '{self._user_list[user_id_that_left]}'.")
-            del self._user_list[user_id_that_left]
+logged in as '{self._user_name_map[user_id_that_left]}'.")
+            del self._user_name_map[user_id_that_left]
 
         bells_unassigned = []
 
@@ -191,12 +191,12 @@ logged in as '{self._user_list[user_id_that_left]}'.")
     def _on_user_entered(self, data):
         """ Called when the server receives a uew user so we can update our user list. """
         # Add the new user to the user list, so we can match up their ID with their username
-        self._user_list[data['user_id']] = data['username']
+        self._user_name_map[data['user_id']] = data['username']
 
     def _on_user_list(self, user_list):
         """ Called when the server broadcasts a user list when Wheatley joins a tower. """
         for user in user_list['user_list']:
-            self._user_list[user['user_id']] = user['username']
+            self._user_name_map[user['user_id']] = user['username']
 
     def _join_tower(self):
         """ Joins the tower as an anonymous user. """

--- a/wheatley/tower.py
+++ b/wheatley/tower.py
@@ -258,6 +258,9 @@ logged in as '{self._user_name_map[user_id_that_left]}'.")
 
         self._assigned_users[bell] = user
 
+        assert isinstance(user, int) or user is None, \
+               f"User ID {user} is not an integer (it has type {type(user)})."
+
         if user:
             self.logger.info(f"RECEIVED: Assigned bell '{bell}' to '{self.user_name_from_id(user)}'")
         else:

--- a/wheatley/tower.py
+++ b/wheatley/tower.py
@@ -101,15 +101,6 @@ class RingingRoomTower:
         """
         return self._user_list[user_id]
 
-    def user_id_from_name(self, user_name: int) -> str:
-        """
-        Converts a numerical user ID into the corresponding user name, throwing a KeyError if not found.
-        """
-        for u_id, name in self._user_list:
-            if name == user_name:
-                return u_id
-        raise KeyError(f"No user ID found corresponding to {user_name}")
-
     def get_stroke(self, bell: Bell):
         """ Returns the stroke of a given bell. """
         if bell.index >= len(self._bell_state) or bell.index < 0:

--- a/wheatley/tower.py
+++ b/wheatley/tower.py
@@ -91,7 +91,10 @@ class RingingRoomTower:
     def is_bell_assigned_to(self, bell: Bell, user_name: Optional[str]):
         """ Returns true if a given bell is assigned to the given user name. """
         try:
-            return self.user_name_from_id(self._assigned_users.get(bell, None)) == user_name
+            assigned_user_id = self._assigned_users.get(bell, None)
+            if assigned_user_id is None and user_name is None:
+                return True
+            return self.user_name_from_id(assigned_user_id) == user_name
         except KeyError:
             return False
 


### PR DESCRIPTION
This is because RR itself has updated to check assignment by numerical user IDs not user names.  So we need to release a new Wheatley version when this update lands on the main RR site (which will probably be Thursday).