### PR TITLE
Add own bells to dataset

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,13 +1,13 @@
 # 0.4.0 (W.I.P.)
 - Replaced `--max-rows-in-dataset` with `--max-bells-in-dataset` to prevent overfitting when
-  Wheatley is ringing most of the bells.
+  Wheatley is ringing most of the bells
 - Keep Wheatley's behaviour consistent with Ringing Room's when tower sizes are changed
-- Change the minimum number of bells required for regression from `2` to defaulting to `4`.
-- Group CLI args into groups for better readability of both code and help messages.
-- Overhaul help and debug messages to use `Wheatley` rather than `bot`.
-- Added CLI arg `--name` to tell Wheatley to ring bells assigned to a specific person.
+- Change the minimum number of bells required for regression from `2` to defaulting to `4`
 - Make Wheatley add his own bells to the regression dataset whilst ringing (this improves the
   stability of the ringing speed when Wheatley is ringing nearly all the bells)
+- Group CLI args into groups for better readability of both code and help messages
+- Overhaul help and debug messages to use `Wheatley` rather than `bot`
+- Added CLI arg `--name` to tell Wheatley to ring bells assigned to a specific person
 - Fix all the examples in `README.md` and add integration tests to prevent breaking them again.
 - Fix `assert` being tripped by methods with an odd lead length
 - Fix incorrect expansion of multiple `x`s in Place Notation

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,8 @@
 - Group CLI args into groups for better readability of both code and help messages.
 - Overhaul help and debug messages to use `Wheatley` rather than `bot`.
 - Added CLI arg `--name` to tell Wheatley to ring bells assigned to a specific person.
+- Make Wheatley add his own bells to the regression dataset whilst ringing (this improves the
+  stability of the ringing speed when Wheatley is ringing nearly all the bells)
 - Fix all the examples in `README.md` and add integration tests to prevent breaking them again.
 - Fix `assert` being tripped by methods with an odd lead length
 - Fix incorrect expansion of multiple `x`s in Place Notation

--- a/tests/test_wait_for_user_rhythm.py
+++ b/tests/test_wait_for_user_rhythm.py
@@ -30,8 +30,7 @@ class WaitForUserRhythmTests(unittest.TestCase):
         self._finished_test = True
 
     def _patched_sleep(self, seconds):
-        """
-        Replacement sleep function that loops until advance_patched_sleep() is called.
+        """ Replacement sleep function that loops until advance_patched_sleep() is called.
         Allows controlling how many times sleep() returns.
         """
         self._sleeping = True
@@ -51,8 +50,7 @@ class WaitForUserRhythmTests(unittest.TestCase):
             self._return_from_sleep = True
 
     def start_wait_for_bell_time_thread(self, current_time, bell, row_number, place, user_controlled, stroke):
-        """
-        Runs wait_for_bell_time() on a different thread, as it should loop until on_bell_ring() is called
+        """ Runs wait_for_bell_time() on a different thread, as it should loop until on_bell_ring() is called
         """
 
         def _wait_for_bell_time():

--- a/tests/test_wait_for_user_rhythm.py
+++ b/tests/test_wait_for_user_rhythm.py
@@ -77,14 +77,14 @@ class WaitForUserRhythmTests(unittest.TestCase):
         self._return_from_sleep = False
 
     def test_on_bell_ring__no_initial_delay(self):
-        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE)
+        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE, True)
 
         self.wait_rhythm.on_bell_ring(treble, HANDSTROKE, 0.5)
 
         self.mock_inner_rhythm.on_bell_ring.assert_called_once_with(treble, HANDSTROKE, 0.5)
 
     def test_on_bell_ring__subtracts_existing_delay(self):
-        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE)
+        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE, True)
         self.wait_rhythm.delay = 10
 
         self.wait_rhythm.on_bell_ring(treble, HANDSTROKE, 10.5)
@@ -97,7 +97,7 @@ class WaitForUserRhythmTests(unittest.TestCase):
         expected_time = 11
         actual_time = 11.1
 
-        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE)
+        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE, True)
         self.wait_rhythm.delay = initial_delay
 
         # Start waiting for treble
@@ -123,7 +123,7 @@ class WaitForUserRhythmTests(unittest.TestCase):
         actual_time = 10.5
 
         self.wait_rhythm.delay = initial_delay
-        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE)
+        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE, True)
 
         # Treble rung by user
         self.wait_rhythm.on_bell_ring(treble, HANDSTROKE, actual_time)
@@ -145,8 +145,8 @@ class WaitForUserRhythmTests(unittest.TestCase):
         expected_first_bell_time = 1
         expected_second_bell_time = 2
 
-        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE)
-        self.wait_rhythm.expect_bell(second, 1, 2, HANDSTROKE)
+        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE, True)
+        self.wait_rhythm.expect_bell(second, 1, 2, HANDSTROKE, True)
         self.wait_rhythm.delay = initial_delay
 
         # Start waiting for treble
@@ -182,7 +182,7 @@ class WaitForUserRhythmTests(unittest.TestCase):
         expected_first_time = 1
         expected_second_time = 2
 
-        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE)
+        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE, True)
         self.wait_rhythm.delay = initial_delay
 
         # Treble rung by user twice, so is now on wrong stroke
@@ -194,7 +194,7 @@ class WaitForUserRhythmTests(unittest.TestCase):
         self.assert_not_waiting_for_bell_time()
 
         # Next row, treble is already rung BACKSTROKE
-        self.wait_rhythm.expect_bell(treble, 2, 1, BACKSTROKE)
+        self.wait_rhythm.expect_bell(treble, 2, 1, BACKSTROKE, True)
 
         self.start_wait_for_bell_time_thread(current_time=expected_second_time, bell=treble, row_number=2,
                                              place=1, user_controlled=True, stroke=BACKSTROKE)
@@ -211,7 +211,7 @@ class WaitForUserRhythmTests(unittest.TestCase):
         expected_first_time = 1
         expected_second_time = 2
 
-        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE)
+        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE, True)
 
         # Treble rung by user
         self.wait_rhythm.on_bell_ring(treble, HANDSTROKE, 1)
@@ -225,7 +225,7 @@ class WaitForUserRhythmTests(unittest.TestCase):
 
         self.assert_not_waiting_for_bell_time()
 
-        self.wait_rhythm.expect_bell(treble, 2, 1, BACKSTROKE)
+        self.wait_rhythm.expect_bell(treble, 2, 1, BACKSTROKE, True)
 
         self.start_wait_for_bell_time_thread(current_time=expected_second_time, bell=treble, row_number=2,
                                              place=1, user_controlled=True, stroke=BACKSTROKE)

--- a/tests/test_wait_for_user_rhythm.py
+++ b/tests/test_wait_for_user_rhythm.py
@@ -12,6 +12,9 @@ treble = Bell.from_number(1)
 second = Bell.from_number(2)
 
 
+USER_CONTROLLED = True
+
+
 class WaitForUserRhythmTests(unittest.TestCase):
     def setUp(self):
         self.mock_inner_rhythm = Mock(spec=Rhythm)
@@ -75,14 +78,14 @@ class WaitForUserRhythmTests(unittest.TestCase):
         self._return_from_sleep = False
 
     def test_on_bell_ring__no_initial_delay(self):
-        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE, True)
+        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE, USER_CONTROLLED)
 
         self.wait_rhythm.on_bell_ring(treble, HANDSTROKE, 0.5)
 
         self.mock_inner_rhythm.on_bell_ring.assert_called_once_with(treble, HANDSTROKE, 0.5)
 
     def test_on_bell_ring__subtracts_existing_delay(self):
-        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE, True)
+        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE, USER_CONTROLLED)
         self.wait_rhythm.delay = 10
 
         self.wait_rhythm.on_bell_ring(treble, HANDSTROKE, 10.5)
@@ -95,7 +98,7 @@ class WaitForUserRhythmTests(unittest.TestCase):
         expected_time = 11
         actual_time = 11.1
 
-        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE, True)
+        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE, USER_CONTROLLED)
         self.wait_rhythm.delay = initial_delay
 
         # Start waiting for treble
@@ -121,7 +124,7 @@ class WaitForUserRhythmTests(unittest.TestCase):
         actual_time = 10.5
 
         self.wait_rhythm.delay = initial_delay
-        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE, True)
+        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE, USER_CONTROLLED)
 
         # Treble rung by user
         self.wait_rhythm.on_bell_ring(treble, HANDSTROKE, actual_time)
@@ -143,8 +146,8 @@ class WaitForUserRhythmTests(unittest.TestCase):
         expected_first_bell_time = 1
         expected_second_bell_time = 2
 
-        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE, True)
-        self.wait_rhythm.expect_bell(second, 1, 2, HANDSTROKE, True)
+        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE, USER_CONTROLLED)
+        self.wait_rhythm.expect_bell(second, 1, 2, HANDSTROKE, USER_CONTROLLED)
         self.wait_rhythm.delay = initial_delay
 
         # Start waiting for treble
@@ -180,7 +183,7 @@ class WaitForUserRhythmTests(unittest.TestCase):
         expected_first_time = 1
         expected_second_time = 2
 
-        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE, True)
+        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE, USER_CONTROLLED)
         self.wait_rhythm.delay = initial_delay
 
         # Treble rung by user twice, so is now on wrong stroke
@@ -192,7 +195,7 @@ class WaitForUserRhythmTests(unittest.TestCase):
         self.assert_not_waiting_for_bell_time()
 
         # Next row, treble is already rung BACKSTROKE
-        self.wait_rhythm.expect_bell(treble, 2, 1, BACKSTROKE, True)
+        self.wait_rhythm.expect_bell(treble, 2, 1, BACKSTROKE, USER_CONTROLLED)
 
         self.start_wait_for_bell_time_thread(current_time=expected_second_time, bell=treble, row_number=2,
                                              place=1, user_controlled=True, stroke=BACKSTROKE)
@@ -209,7 +212,7 @@ class WaitForUserRhythmTests(unittest.TestCase):
         expected_first_time = 1
         expected_second_time = 2
 
-        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE, True)
+        self.wait_rhythm.expect_bell(treble, 1, 1, HANDSTROKE, USER_CONTROLLED)
 
         # Treble rung by user
         self.wait_rhythm.on_bell_ring(treble, HANDSTROKE, 1)
@@ -223,7 +226,7 @@ class WaitForUserRhythmTests(unittest.TestCase):
 
         self.assert_not_waiting_for_bell_time()
 
-        self.wait_rhythm.expect_bell(treble, 2, 1, BACKSTROKE, True)
+        self.wait_rhythm.expect_bell(treble, 2, 1, BACKSTROKE, USER_CONTROLLED)
 
         self.start_wait_for_bell_time_thread(current_time=expected_second_time, bell=treble, row_number=2,
                                              place=1, user_controlled=True, stroke=BACKSTROKE)

--- a/tests/test_wait_for_user_rhythm.py
+++ b/tests/test_wait_for_user_rhythm.py
@@ -30,7 +30,8 @@ class WaitForUserRhythmTests(unittest.TestCase):
         self._finished_test = True
 
     def _patched_sleep(self, seconds):
-        """ Replacement sleep function that loops until advance_patched_sleep() is called
+        """
+        Replacement sleep function that loops until advance_patched_sleep() is called.
         Allows controlling how many times sleep() returns.
         """
         self._sleeping = True
@@ -42,9 +43,7 @@ class WaitForUserRhythmTests(unittest.TestCase):
         self._sleeping = False
 
     def advance_patched_sleep(self, seconds: float = 0.01):
-        """ Makes _patched_sleep() return
-        Allows controlling how many times sleep() returns.
-        """
+        """ Makes _patched_sleep() return. Allows controlling how many times sleep() returns.  """
         expected_sleeps = seconds / WaitForUserRhythm.sleep_time
         for _ in range(round(expected_sleeps)):
             while not self._sleeping or self._return_from_sleep:
@@ -52,7 +51,8 @@ class WaitForUserRhythmTests(unittest.TestCase):
             self._return_from_sleep = True
 
     def start_wait_for_bell_time_thread(self, current_time, bell, row_number, place, user_controlled, stroke):
-        """ Runs wait_for_bell_time() on a different thread, as it should loop until on_bell_ring() is called
+        """
+        Runs wait_for_bell_time() on a different thread, as it should loop until on_bell_ring() is called
         """
 
         def _wait_for_bell_time():

--- a/wheatley/bot.py
+++ b/wheatley/bot.py
@@ -131,7 +131,7 @@ into changes unless something is done!")
         """ Callback called when the Tower receives a signal that a bell has been rung. """
         # This will give us the stroke _after_ the bell rings, we have to invert it, because otherwise this
         # will always expect the bells on the wrong stroke and no ringing will ever happen
-        self._rhythm.on_bell_ring(bell, not stroke, time.time(), self._user_assigned_bell(bell))
+        self._rhythm.on_bell_ring(bell, not stroke, time.time())
 
     # Mainloop and helper methods
     def expect_bell(self, index, bell):

--- a/wheatley/bot.py
+++ b/wheatley/bot.py
@@ -129,11 +129,9 @@ into changes unless something is done!")
 
     def _on_bell_ring(self, bell, stroke):
         """ Callback called when the Tower receives a signal that a bell has been rung. """
-        if self._user_assigned_bell(bell):
-            # This will give us the stroke _after_ the bell rings, we have to invert it, because
-            # otherwise this will always expect the bells on the wrong stroke and no ringing will
-            # ever happen
-            self._rhythm.on_bell_ring(bell, not stroke, time.time())
+        # This will give us the stroke _after_ the bell rings, we have to invert it, because otherwise this
+        # will always expect the bells on the wrong stroke and no ringing will ever happen
+        self._rhythm.on_bell_ring(bell, not stroke, time.time(), self._user_assigned_bell(bell))
 
     # Mainloop and helper methods
     def expect_bell(self, index, bell):

--- a/wheatley/bot.py
+++ b/wheatley/bot.py
@@ -136,13 +136,8 @@ into changes unless something is done!")
     # Mainloop and helper methods
     def expect_bell(self, index, bell):
         """ Called to let the rhythm expect a user-controlled bell at a certain time and stroke. """
-        if self._user_assigned_bell(bell):
-            self._rhythm.expect_bell(
-                bell,
-                self._row_number,
-                index,
-                self.is_handstroke
-            )
+        self._rhythm.expect_bell(bell, self._row_number, index, self.is_handstroke,
+                                 self._user_assigned_bell(bell))
 
     def start_next_row(self):
         """

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -65,6 +65,10 @@ def create_rhythm(args):
     # Wheatley more sensitive to user's pull-off speed.  If this is larger than `--max_bells_in_dataset`,
     # this will be clamped to fit.
     min_bells_in_dataset = 4
+    # Tells Wheatley whether or not to use his own bells to gauge the ringing speed.  By default, Wheatley
+    # *does* store use his own ringing because doing so makes the ringing much more stable regardless of the
+    # proportion of user-controlled bells."
+    include_own_bells = True
 
     # Clamp min_bells_in_dataset to not be bigger than max_bells_in_dataset
     min_bells_in_dataset = min(min_bells_in_dataset, args.max_bells_in_dataset)
@@ -74,7 +78,8 @@ def create_rhythm(args):
         handstroke_gap=args.handstroke_gap,
         peal_speed=peal_speed,
         min_bells_in_dataset=min_bells_in_dataset,
-        max_bells_in_dataset=args.max_bells_in_dataset
+        max_bells_in_dataset=args.max_bells_in_dataset,
+        include_own_bells=include_own_bells
     )
 
     if not args.keep_going:


### PR DESCRIPTION
Add option to make Wheatley add his own bells to the regression dataset (which is on by default).  This will hopefully prevent Wheatley overfitting to the users' bells when Wheatley is ringing the majority of the bells.

Resolves #97