### PR TITLE
Update Wheatley to the new unassign behaviour

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,6 +1,7 @@
 # 0.4.0 (W.I.P.)
 - Replaced `--max-rows-in-dataset` with `--max-bells-in-dataset` to prevent overfitting when
   Wheatley is ringing most of the bells.
+- Keep Wheatley's behaviour consistent with Ringing Room's when tower sizes are changed
 - Change the minimum number of bells required for regression from `2` to defaulting to `4`.
 - Group CLI args into groups for better readability of both code and help messages.
 - Overhaul help and debug messages to use `Wheatley` rather than `bot`.

--- a/wheatley/tower.py
+++ b/wheatley/tower.py
@@ -245,8 +245,18 @@ logged in as '{self._user_name_map[user_id_that_left]}'.")
         """ Callback called when the number of bells in the room changes. """
         new_size = data["size"]
         if new_size != self.number_of_bells:
-            self._assigned_users = {}
+            # Remove the user who's bells have been removed (so that returning to a stage doesn't make
+            # Wheatley think the bells are still assigned)
+            bells_to_unassign = []
+            for bell in self._assigned_users:
+                if bell.number > new_size:
+                    bells_to_unassign.append(bell)
+            for b in bells_to_unassign:
+                del self._assigned_users[b]
+            print(self._assigned_users)
+            # Set the bells at handstroke
             self._bell_state = self._bells_set_at_hand(new_size)
+            # Handle all the callbacks
             self.logger.info(f"RECEIVED: New tower size '{new_size}'")
             for invoke_callback in self.invoke_on_reset:
                 invoke_callback()

--- a/wheatley/tower.py
+++ b/wheatley/tower.py
@@ -247,13 +247,8 @@ logged in as '{self._user_name_map[user_id_that_left]}'.")
         if new_size != self.number_of_bells:
             # Remove the user who's bells have been removed (so that returning to a stage doesn't make
             # Wheatley think the bells are still assigned)
-            bells_to_unassign = []
-            for bell in self._assigned_users:
-                if bell.number > new_size:
-                    bells_to_unassign.append(bell)
-            for b in bells_to_unassign:
-                del self._assigned_users[b]
-            print(self._assigned_users)
+            self._assigned_users = {bell: user for (bell, user) in self._assigned_users.items()
+                                               if bell.number <= new_size}
             # Set the bells at handstroke
             self._bell_state = self._bells_set_at_hand(new_size)
             # Handle all the callbacks


### PR DESCRIPTION
Wheatley would previously clear the bell assignment list whenever the tower size was changed, which is now out of sync with Ringing Room's behaviour.