### PR TITLE
Correct initial_inertia

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,4 +1,4 @@
-# 0.5.0
+# 0.5.1
 - Fix invalid initial inertia.
 
 # 0.5.0

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,4 +1,7 @@
 # 0.5.0
+- Fix invalid initial inertia.
+
+# 0.5.0
 - Add mode for running Wheatley on a Ringing Room server.
 
 # 0.4.0

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -53,7 +53,7 @@ def create_row_generator(args):
     return row_gen
 
 
-def create_rhythm(peal_speed, inertia, max_bells_in_dataset, handstroke_gap, use_wait, initial_inertia=None):
+def create_rhythm(peal_speed, inertia, max_bells_in_dataset, handstroke_gap, use_wait, initial_inertia=0):
     """ Generates a rhythm object according to the given CLI arguments. """
     # Sets the minimum number of bells that Wheatley will use in order to deduce a rhythm.  Setting this to
     # larger numbers will make Wheatley more stable during the pull-off, whereas smaller numbers will make


### PR DESCRIPTION
An initial_inertia of `None` with >3 ringers (or >2 if Wheatley rings the treble) is passed to the `lerp` function which then crashes.

Fixes #107