### PR TITLE
Add summary string

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -3,6 +3,7 @@
 - Allow support of the new tower sizes - `5`, `14` and `16`
 - Allow Wheatley to ring with any (positive) number of cover bells
 - Add full static typing, and fix some `None`-related bugs
+- Print summary string of what Wheatley is going to ring
 
 # 0.5.1
 - Fix invalid initial inertia.

--- a/tests/row_generation/test_ComplibCompositionRowGenerator.py
+++ b/tests/row_generation/test_ComplibCompositionRowGenerator.py
@@ -1,0 +1,25 @@
+import unittest
+from unittest import TestCase
+
+
+from wheatley.row_generation import ComplibCompositionGenerator
+
+
+class CompLibGeneratorTests(TestCase):
+    def test_comp_fetching(self):
+        for (url, expected_title) in [
+            ("complib.org/composition/62355", "5040 Plain Bob Major Op. Cyclic #1 by Ben White-Horne"),
+            ("www.complib.org/composition/62355", "5040 Plain Bob Major Op. Cyclic #1 by Ben White-Horne"),
+            ("https://www.complib.org/composition/71994", "110 2-Spliced Major"),
+            ("https://complib.org/composition/71994", "110 2-Spliced Major"),
+            (
+                "https://complib.org/composition/70383?accessKey=cf75d5e0d213d4d3ea38f58f5bfdfd8e86b99ccf",
+                "56 3-Spliced Bob Royal"
+            )
+        ]:
+            with self.subTest(url=url, expected_title=expected_title):
+                self.assertEqual(ComplibCompositionGenerator.from_url(url).comp_title, expected_title)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/row_generation/test_MethodPlaceNotationGenerator.py
+++ b/tests/row_generation/test_MethodPlaceNotationGenerator.py
@@ -9,6 +9,7 @@ plain_bob_minimus = """<?xml version="1.0"?>
 <methods xmlns="http://methods.ringing.org/NS/method" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:db="http://methods.ringing.org/NS/database" xmlns:ns_1="http://methods.ringing.org/NS/database" version="0.1" ns_1:page="0" ns_1:pagesize="100" ns_1:rows="1">
   <method xmlns:a="http://methods.ringing.org/NS/method" id="m13199">
     <stage>4</stage>
+    <title>Plain Bob Minimus</title>
     <pn>
       <symblock>-14-14</symblock>
       <symblock>12</symblock>
@@ -21,6 +22,7 @@ single_oxford_triples = """<?xml version="1.0"?>
 <methods xmlns="http://methods.ringing.org/NS/method" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:db="http://methods.ringing.org/NS/database" xmlns:ns_1="http://methods.ringing.org/NS/database" version="0.1" ns_1:page="0" ns_1:pagesize="100" ns_1:rows="1">
   <method xmlns:a="http://methods.ringing.org/NS/method" id="m14153">
     <stage>7</stage>
+    <title>Single Oxford Bob Triples</title>
     <pn>
       <symblock>3</symblock>
       <symblock>1.5.1.7.1.7.1</symblock>
@@ -33,6 +35,7 @@ scientific_triples = """<?xml version="1.0"?>
 <methods xmlns="http://methods.ringing.org/NS/method" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:db="http://methods.ringing.org/NS/database" xmlns:ns_1="http://methods.ringing.org/NS/database" version="0.1" ns_1:page="0" ns_1:pagesize="100" ns_1:rows="1">
   <method xmlns:a="http://methods.ringing.org/NS/method" id="m26235">
     <stage>7</stage>
+    <title>Scientific Triples</title>
     <pn>
       <block>3.1.7.1.5.1.7.1.7.5.1.7.1.7.1.7.1.7.1.5.1.5.1.7.1.7.1.7.1.7</block>
     </pn>
@@ -43,19 +46,22 @@ scientific_triples = """<?xml version="1.0"?>
 
 class MethodPlaceNotationGeneratorTests(TestCase):
     def test_parse_symblock_even(self):
-        method_pn, stage = MethodPlaceNotationGenerator._parse_xml(plain_bob_minimus)
+        method_pn, stage, title = MethodPlaceNotationGenerator._parse_xml(plain_bob_minimus)
         self.assertEqual("&-14-14,&12", method_pn)
         self.assertEqual(4, stage)
+        self.assertEqual("Plain Bob Minimus", title)
 
     def test_parse_symblock_odd(self):
-        method_pn, stage = MethodPlaceNotationGenerator._parse_xml(single_oxford_triples)
+        method_pn, stage, title = MethodPlaceNotationGenerator._parse_xml(single_oxford_triples)
         self.assertEqual("&3,&1.5.1.7.1.7.1", method_pn)
         self.assertEqual(7, stage)
+        self.assertEqual("Single Oxford Bob Triples", title)
 
     def test_parse_block(self):
-        method_pn, stage = MethodPlaceNotationGenerator._parse_xml(scientific_triples)
+        method_pn, stage, title = MethodPlaceNotationGenerator._parse_xml(scientific_triples)
         self.assertEqual("3.1.7.1.5.1.7.1.7.5.1.7.1.7.1.7.1.7.1.5.1.5.1.7.1.7.1.7.1.7", method_pn)
         self.assertEqual(7, stage)
+        self.assertEqual("Scientific Triples", title)
 
 
 class SpecialMethodNameTests(TestCase):

--- a/wheatley/bot.py
+++ b/wheatley/bot.py
@@ -77,6 +77,9 @@ class Bot:
 
         self.logger = logging.getLogger(self.logger_name)
 
+        # Log what we're going to ring
+        self.logger.info(f"Wheatley will ring {self.row_generator.summary_string()}")
+
     # Convenient properties that are frequently used
     @property
     def stroke(self) -> Stroke:
@@ -111,7 +114,7 @@ class Bot:
     def _on_row_gen_change(self, row_gen_json: JSON) -> None:
         try:
             self.next_row_generator = json_to_row_generator(row_gen_json, self.logger)
-            self.logger.info("Successfully updated next row gen")
+            self.logger.info(f"Next touch, Wheatley will ring {self.next_row_generator.summary_string()}")
         except RowGenParseError as e:
             self.logger.warning(e)
 
@@ -171,7 +174,6 @@ class Bot:
         # Start at the first place of the first row
         self._row_number = 0
         self._place = 0
-
         self.start_next_row()
 
     def _on_go(self) -> None:
@@ -308,7 +310,7 @@ class Bot:
                     self.logger.info(f"Timed out - no activity for {INACTIVITY_EXIT_TIME}s. Exiting.")
                     return
 
-            self.logger.info("Starting to ring!")
+            self.logger.info(f"Starting to ring {self.row_generator.summary_string()}")
             if self._server_mode:
                 self._tower.set_is_ringing(True)
 

--- a/wheatley/row_generation/complib_composition_generator.py
+++ b/wheatley/row_generation/complib_composition_generator.py
@@ -1,6 +1,7 @@
 """ Contains the RowGenerator subclass for generating rows from a CompLib composition. """
 
-from typing import Optional, List
+import json
+from typing import Optional, List, Tuple
 
 import requests
 
@@ -58,31 +59,36 @@ def removeprefix(string: str, prefix: str) -> str:
 class ComplibCompositionGenerator(RowGenerator):
     """ The RowGenerator subclass for generating rows from a CompLib composition. """
 
-    complib_url = "https://complib.org/composition/"
+    complib_url = "https://api.complib.org/composition/"
 
     def __init__(self, comp_id: int, access_key: Optional[str]=None) -> None:
+        # Generate URL and request the rows
         url = self.complib_url + str(comp_id) + "/rows"
         if access_key:
             url += "?accessKey=" + access_key
         request_rows = requests.get(url)
-
+        # Check for the status of the requests
         if request_rows.status_code == 404:
             raise InvalidCompError(comp_id)
-
         if request_rows.status_code == 403:
             raise PrivateCompError(comp_id)
-
         request_rows.raise_for_status()
+        # Parse the request responses as JSON
+        response_rows = json.loads(request_rows.text)
 
-        # New line separated, skip the first line (rounds)
-        split_rows = request_rows.text.splitlines(False)[1::]
-        self.loaded_rows: List[Row] = [Row([Bell.from_str(bell) for bell in row]) for row in split_rows]
-
-        stage = len(self.loaded_rows[0])
+        # Derive the rows, calls and stage from the JSON response
+        self.loaded_rows: List[Tuple[Row, Optional[str]]] = [
+            (
+                Row([Bell.from_str(bell) for bell in row]),
+                None if call == '' else call
+            ) for row, call, property_bitmap in response_rows['rows'][2:]
+        ]
+        stage = response_rows['stage']
 
         # Variables from which the summary string is generated
         self.comp_id = comp_id
-        self.is_comp_private = False  # We currently can't load private comps, so this is always False
+        self.comp_title = response_rows['title']
+        self.is_comp_private = access_key is not None
 
         super().__init__(stage)
 
@@ -105,7 +111,7 @@ class ComplibCompositionGenerator(RowGenerator):
         main_url_parts = main_url.split("/")
 
         try:
-            if main_url_parts[0] != "complib.org":
+            if not main_url_parts[0].endswith("complib.org"):
                 raise InvalidComplibURLError(url, "Doesn't point to 'complib.org'.")
             if main_url_parts[1] != "composition":
                 raise InvalidComplibURLError(url, "Not a composition.")
@@ -119,10 +125,9 @@ class ComplibCompositionGenerator(RowGenerator):
 
     def summary_string(self) -> str:
         """ Returns a short string summarising the RowGenerator. """
-        return f"{'private ' if self.is_comp_private else ''}comp #{self.comp_id}"
+        return f"{'private ' if self.is_comp_private else ''}comp #{self.comp_id}: {self.comp_title}"
 
     def _gen_row(self, previous_row: Row, stroke: Stroke, index: int) -> Row:
         if index < len(self.loaded_rows):
-            return self.loaded_rows[index]
-
+            return self.loaded_rows[index][0]
         return self.rounds()

--- a/wheatley/row_generation/complib_composition_generator.py
+++ b/wheatley/row_generation/complib_composition_generator.py
@@ -80,6 +80,10 @@ class ComplibCompositionGenerator(RowGenerator):
 
         stage = len(self.loaded_rows[0])
 
+        # Variables from which the summary string is generated
+        self.comp_id = comp_id
+        self.is_comp_private = False  # We currently can't load private comps, so this is always False
+
         super().__init__(stage)
 
     @classmethod
@@ -112,6 +116,10 @@ class ComplibCompositionGenerator(RowGenerator):
             raise InvalidComplibURLError(url, f"ID {main_url_parts[2]} is not an integer.") from e
 
         return cls(comp_id, access_key)
+
+    def summary_string(self) -> str:
+        """ Returns a short string summarising the RowGenerator. """
+        return f"{'private ' if self.is_comp_private else ''}comp #{self.comp_id}"
 
     def _gen_row(self, previous_row: Row, stroke: Stroke, index: int) -> Row:
         if index < len(self.loaded_rows):

--- a/wheatley/row_generation/dixonoids_generator.py
+++ b/wheatley/row_generation/dixonoids_generator.py
@@ -70,6 +70,10 @@ class DixonoidsGenerator(RowGenerator):
         row = self.permute(previous_row, place_notation)
         return row
 
+    def summary_string(self) -> str:
+        """ Returns a short string summarising the RowGenerator. """
+        return f"dixonoid: {self.plain_rules}"
+
     @staticmethod
     def _convert_pn_dict(rules: Dict[int, List[str]]) -> Dict[int, List[Places]]:
         return {key: [convert_pn(pn)[0] for pn in places] for key, places in rules.items()}

--- a/wheatley/row_generation/go_and_stop_calling_generator.py
+++ b/wheatley/row_generation/go_and_stop_calling_generator.py
@@ -28,6 +28,10 @@ class GoAndStopCallingGenerator(RowGenerator):
 
         return super().next_row(stroke)
 
+    def summary_string(self) -> str:
+        """ Returns a short string summarising the RowGenerator. """
+        return f"{self.generator.summary_string}, calling 'Go' and 'Stop'"
+
     def _gen_row(self, previous_row: Row, stroke: Stroke, index: int) -> Row:
         next_row = self.generator._gen_row(previous_row, stroke, index)
 

--- a/wheatley/row_generation/place_holder_generator.py
+++ b/wheatley/row_generation/place_holder_generator.py
@@ -25,5 +25,9 @@ class PlaceHolderGenerator(RowGenerator):
         # Make the stage 0
         super().__init__(0)
 
+    def summary_string(self) -> str:
+        """ Returns a short string summarising the RowGenerator. """
+        return "nothing"
+
     def _gen_row(self, previous_row: Row, stroke: Stroke, index: int) -> Row:
         raise NullRowGenError()

--- a/wheatley/row_generation/place_notation_generator.py
+++ b/wheatley/row_generation/place_notation_generator.py
@@ -27,6 +27,8 @@ class PlaceNotationGenerator(RowGenerator):
 
         self.method_pn = convert_pn(method)
         self.lead_len = len(self.method_pn)
+        # Store the method place notation as a string for the summary string
+        self.method_pn_string = method
 
         def parse_call_dict(unparsed_calls: CallDef) -> Dict[int, List[Places]]:
             """ Parse a dict of type `int => str` to `int => [PlaceNotation]`. """
@@ -47,6 +49,10 @@ class PlaceNotationGenerator(RowGenerator):
         self.singles_pn = parse_call_dict(single)
 
         self._generating_call_pn: List[Places] = []
+
+    def summary_string(self) -> str:
+        """ Returns a short string summarising the RowGenerator. """
+        return f"place notation '{self.method_pn_string}'"
 
     def _gen_row(self, previous_row: Row, stroke: Stroke, index: int) -> Row:
         lead_index = index % self.lead_len

--- a/wheatley/row_generation/plain_hunt_generator.py
+++ b/wheatley/row_generation/plain_hunt_generator.py
@@ -9,6 +9,10 @@ from .row_generator import RowGenerator
 class PlainHuntGenerator(RowGenerator):
     """ A row generator to create plain hunt on any stage. """
 
+    def summary_string(self) -> str:
+        """ Returns a short string summarising the RowGenerator. """
+        return f"Plain Hunt on {self.stage}"
+
     def _gen_row(self, previous_row: Row, stroke: Stroke, index: int) -> Row:
         if stroke.is_hand():
             return self.permute(previous_row, Places([]))

--- a/wheatley/row_generation/row_generator.py
+++ b/wheatley/row_generation/row_generator.py
@@ -65,6 +65,13 @@ class RowGenerator(metaclass=ABCMeta):
     def _gen_row(self, previous_row: Row, stroke: Stroke, index: int) -> Row:
         pass
 
+    @abstractmethod
+    def summary_string(self) -> str:
+        """ Returns a short string summarising the RowGenerator.
+        This should make grammatical sense when formatted with
+        'Wheatley (will ring|is ringing) {summary_string}'.
+        """
+
     def permute(self, row: Row, places: Places) -> Row:
         """ Permute a row by a place notation given by `places`. """
         new_row = list(row)


### PR DESCRIPTION
Wheatley now tells the user what he's about to ring.

For example, running `./run-wheatley 389217546 -c 71878 -u` will print:
```
INFO:BOT:Wheatley will ring comp #71878: 90 Braywood Bob Doubles
...
```

This was originally part of #119, but it makes the diffs for that PR will be much simpler if this is merged separately.