### PR TITLE
Revert the behaviour of `--stop-at-rounds`

### DIFF
--- a/wheatley/bot.py
+++ b/wheatley/bot.py
@@ -275,7 +275,7 @@ class Bot:
                 self._should_start_method = True
 
             # Implement handbell-style stopping at rounds
-            if self._stop_at_rounds and has_just_rung_rounds:
+            if self._stop_at_rounds and has_just_rung_rounds and not self._is_ringing_rounds:
                 self._should_stand = False
                 self._is_ringing = False
 


### PR DESCRIPTION
One side effect of #117 is that the `--stop-at-rounds` flag doesn't discriminate between rounds in and out of method.  The resulting behaviour is that when `--stop-at-rounds` is set, Wheatley would stop ringing after the first set of rounds.

This PR reverts the behaviour by checking that Wheatley is in fact ringing a method.