### PR TITLE
Bump numpy to 1.19.3

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,6 +5,10 @@
 - Add full static typing, and fix some `None`-related bugs
 - Print summary string of what Wheatley is going to ring
 
+# 0.5.2
+- Bump numpy version to exactly `1.19.3` on Windows to fix
+  [this issue](https://tinyurl.com/y3dm3h86).
+
 # 0.5.1
 - Fix invalid initial inertia.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 certifi==2020.4.5.2
 chardet==3.0.4
 idna==2.9
-numpy==1.18.5
+numpy==1.19.3; platform_system == "Windows"
+numpy==1.18.5; platform_system != "Windows"
 mypy==0.790
 mypy-extensions==0.4.3
 pylint==2.6.0

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setuptools.setup(
     ],
     python_requires='>=3.6',
     install_requires=[
-        "numpy",
+        'numpy<=1.19.3; platform_system == "Windows"',
+        'numpy; platform_system != "Windows"',
         "requests",
         "python-socketio",
         "websocket-client"


### PR DESCRIPTION
This is to fix [this issue](https://tinyurl.com/y3dm3h86), which causes Wheatley to crash on Windows computers.  I've had two people come to me so far with this issue.

It doesn't work for `numpy==1.19.4`, which is the latest version.

I also think we should hotfix this change as version `0.5.2` so that people installing Wheatley will get a fixed version.