### PR TITLE
Verbosity control

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -2,12 +2,13 @@
 - Print summary string of what Wheatley is going to ring.
 - Add proper support for backstroke starts (with 3 rows of rounds for `--up-down-in`).
 - Allow support of the new tower sizes - `5`, `14` and `16`.
+- Add `-v`/`--verbose` and `-q`/`--quiet` to change how much stuff Wheatley prints.
 - Allow Wheatley to ring with any (positive) number of cover bells.
 - Add `--start-index` to specify how many rows into a lead of a method Wheatley should start.
 - Tell users when Wheatley is waiting for `Look To`.
 - Change place notation parsing to comply with CompLib and the XML specification.
 - Add full static typing, and fix some `None`-related bugs.
-- Prevent installing the wrong version of socketio to work with RingingRoom
+- Prevent installing the wrong version of socketio to work with RingingRoom.
 
 # 0.5.2
 - Bump numpy version to exactly `1.19.3` on Windows to fix

--- a/tests/test_stroke.py
+++ b/tests/test_stroke.py
@@ -37,6 +37,10 @@ class StrokeTests(unittest.TestCase):
         self.assertEqual(str(HANDSTROKE), 'HANDSTROKE')
         self.assertEqual(str(BACKSTROKE), 'BACKSTROKE')
 
+    def test_to_char(self):
+        self.assertEqual(HANDSTROKE.char(), 'H')
+        self.assertEqual(BACKSTROKE.char(), 'B')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/wheatley/stroke.py
+++ b/wheatley/stroke.py
@@ -30,6 +30,10 @@ class Stroke:
         """ Returns the opposite Stroke to the current one. """
         return Stroke(not self._is_handstroke)
 
+    def char(self) -> str:
+        """ Returns a single-character string of 'H' or 'B'. """
+        return "H" if self._is_handstroke else "B"
+
     def __str__(self) -> str:
         return "HANDSTROKE" if self._is_handstroke else "BACKSTROKE"
 

--- a/wheatley/tower.py
+++ b/wheatley/tower.py
@@ -272,7 +272,7 @@ logged in as '{self._user_name_map[user_id_that_left]}'.")
 
     def _update_bell_state(self, bell_state: List[Stroke]) -> None:
         self._bell_state = bell_state
-        self.logger.debug(f"RECEIVED: Bells '{['H' if x else 'B' for x in bell_state]}'")
+        self.logger.debug(f"RECEIVED: Bells '{''.join([s.char() for s in bell_state])}'")
 
     def _on_global_bell_state(self, data: JSON) -> None:
         """


### PR DESCRIPTION
Adds `-v`/`--verbose` and `-q`/`--quiet` for controlling how much logging Wheatley prints.

By the way, is there an elegant way to add extra logging levels?  I think it'd be useful to have two extra levels:
- `TRACE` which would be more verbose than `DEBUG`, and used logging control flow for debugging (rust has this and it's really useful).
- It'd also be nice to have two `INFO` levels to give the user a bit of control, but this could probably be offset by strategically moving things from `INFO` to `DEBUG`.