### PR TITLE
Add custom start row index and backstroke starts

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,9 +1,10 @@
 # 0.6.0 (W.I.P.)
 - Print summary string of what Wheatley is going to ring.
-- Tell users when Wheatley is waiting for `Look To`.
+- Add proper support for backstroke starts (with 3 rows of rounds for `--up-down-in`).
 - Allow support of the new tower sizes - `5`, `14` and `16`.
-- Change place notation parsing to comply with CompLib and the XML specification.
 - Allow Wheatley to ring with any (positive) number of cover bells.
+- Tell users when Wheatley is waiting for `Look To`.
+- Change place notation parsing to comply with CompLib and the XML specification.
 - Add full static typing, and fix some `None`-related bugs.
 
 # 0.5.2

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -3,6 +3,7 @@
 - Add proper support for backstroke starts (with 3 rows of rounds for `--up-down-in`).
 - Allow support of the new tower sizes - `5`, `14` and `16`.
 - Allow Wheatley to ring with any (positive) number of cover bells.
+- Add `--start-index` to specify how many rows into a lead of a method Wheatley should start.
 - Tell users when Wheatley is waiting for `Look To`.
 - Change place notation parsing to comply with CompLib and the XML specification.
 - Add full static typing, and fix some `None`-related bugs.

--- a/tests/test_stroke.py
+++ b/tests/test_stroke.py
@@ -23,6 +23,12 @@ class StrokeTests(unittest.TestCase):
         self.assertEqual(HANDSTROKE.is_back(), False)
         self.assertEqual(BACKSTROKE.is_back(), True)
 
+    def test_from_index(self):
+        stroke = HANDSTROKE
+        for i in range(-100, 100):
+            self.assertEqual(Stroke.from_index(i), stroke)
+            stroke = stroke.opposite()
+
     def test_opposite(self):
         self.assertEqual(HANDSTROKE.opposite(), BACKSTROKE)
         self.assertEqual(BACKSTROKE.opposite(), HANDSTROKE)

--- a/wheatley/bot.py
+++ b/wheatley/bot.py
@@ -270,6 +270,10 @@ class Bot:
             self._place = 0
             self.start_next_row()
 
+            next_stroke = Stroke.from_index(self._row_number)
+
+            # ===== SET FLAGS FOR HANDBELL-STYLE RINGING =====
+
             # Implement handbell-style 'up down in'
             if self._do_up_down_in and self._is_ringing_rounds and self._row_number == 2:
                 self._should_start_method = True
@@ -279,17 +283,19 @@ class Bot:
                 self._should_stand = False
                 self._is_ringing = False
 
+            # ===== CONVERT THE FLAGS INTO ACTIONS =====
+
+            if self._should_start_method and self._is_ringing_rounds \
+               and next_stroke == self.row_generator.start_stroke():
+                self._should_start_method = False
+                self._is_ringing_rounds = False
+                self.start_method()
+
             # If we're starting a handstroke, we should convert all the flags into actions
-            if self._row_number % 2 == 0:
+            if next_stroke.is_hand():
                 if self._should_stand:
                     self._should_stand = False
                     self._is_ringing = False
-
-                if self._should_start_method and self._is_ringing_rounds:
-                    self._should_start_method = False
-                    self._is_ringing_rounds = False
-
-                    self.start_method()
 
                 if self._should_start_ringing_rounds and not self._is_ringing_rounds:
                     self._should_start_ringing_rounds = False

--- a/wheatley/bot.py
+++ b/wheatley/bot.py
@@ -84,7 +84,7 @@ class Bot:
     @property
     def stroke(self) -> Stroke:
         """ Returns true if the current row (determined by self._row_number) represents a handstroke. """
-        return Stroke(self._row_number % 2 == 0)
+        return Stroke.from_index(self._row_number)
 
     @property
     def number_of_bells(self) -> int:
@@ -248,7 +248,7 @@ class Bot:
             self.start_next_row()
 
     def tick(self) -> None:
-        """ Called every time the main loop is executed when the bot is ringing. """
+        """ Move the ringing on by one place """
 
         bell = self._row[self._place]
         user_controlled = self._user_assigned_bell(bell)

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -44,7 +44,8 @@ def create_row_generator(args: argparse.Namespace) -> RowGenerator:
                       MethodPlaceNotationGenerator(
                           args.method,
                           parse_call(args.bob),
-                          parse_call(args.single)
+                          parse_call(args.single),
+                          args.start_index
                       )
         except MethodNotFoundError as e:
             sys.exit(f"Bad value for '--method': {e}")
@@ -259,6 +260,13 @@ def console_main(override_args: Optional[List[str]], stop_on_join_tower: bool) -
               "0:1678" => 6ths place lead end single.  "-1:3.123" => a Grandsire Single. \
               "20: 7890" => a 7890 single taking effect 20 changes into a lead (the Half Lead for \
               Surprise Royal). "3: 567/9: 567" => singles in Stedman Triples.  Defaults to "1234".'
+    )
+    row_gen_group.add_argument(
+        "--start-index",
+        type=int,
+        default=0,
+        help="Determines which row of the lead Wheatley will start ringing.  This can be negative (so -1 \
+              would refer to the lead **end**).  Defaults to 0 (i.e. a standard start)."
     )
     row_gen_group.add_argument(
         "-u", "--use-up-down-in",

--- a/wheatley/row_generation/method_place_notation_generator.py
+++ b/wheatley/row_generation/method_place_notation_generator.py
@@ -59,7 +59,7 @@ class MethodNotFoundError(ValueError):
 class MethodPlaceNotationGenerator(PlaceNotationGenerator):
     """ A class to generate rows given a method title. """
 
-    def __init__(self, method_title: str, bob: CallDef, single: CallDef) -> None:
+    def __init__(self, method_title: str, bob: CallDef, single: CallDef, start_row: int = 0) -> None:
         method_xml = self._fetch_method(method_title)
 
         try:
@@ -72,7 +72,8 @@ class MethodPlaceNotationGenerator(PlaceNotationGenerator):
             stage,
             method_pn,
             bob,
-            single
+            single,
+            start_row
         )
 
     def summary_string(self) -> str:

--- a/wheatley/row_generation/place_notation_generator.py
+++ b/wheatley/row_generation/place_notation_generator.py
@@ -17,7 +17,8 @@ class PlaceNotationGenerator(RowGenerator):
     DefaultBob: ClassVar[CallDef] = CallDef({0: '14'})
     DefaultSingle: ClassVar[CallDef] = CallDef({0: '1234'})
 
-    def __init__(self, stage: int, method: str, bob: CallDef = None, single: CallDef = None) -> None:
+    def __init__(self, stage: int, method: str, bob: CallDef = None, single: CallDef = None,
+                 start_index: int = 0) -> None:
         super().__init__(stage)
 
         if bob is None:
@@ -29,6 +30,7 @@ class PlaceNotationGenerator(RowGenerator):
         self.lead_len = len(self.method_pn)
         # Store the method place notation as a string for the summary string
         self.method_pn_string = method
+        self.start_index = start_index
 
         def parse_call_dict(unparsed_calls: CallDef) -> Dict[int, List[Places]]:
             """ Parse a dict of type `int => str` to `int => [PlaceNotation]`. """
@@ -55,7 +57,8 @@ class PlaceNotationGenerator(RowGenerator):
         return f"place notation '{self.method_pn_string}'"
 
     def _gen_row(self, previous_row: Row, stroke: Stroke, index: int) -> Row:
-        lead_index = index % self.lead_len
+        assert self.lead_len > 0
+        lead_index = (index + self.start_index) % self.lead_len
 
         if self._has_bob and self.bobs_pn.get(lead_index):
             self._generating_call_pn = list(self.bobs_pn[lead_index])
@@ -72,6 +75,9 @@ class PlaceNotationGenerator(RowGenerator):
             place_notation = self.method_pn[lead_index]
 
         return self.permute(previous_row, place_notation)
+
+    def start_stroke(self) -> Stroke:
+        return Stroke.from_index(self.start_index)
 
     @staticmethod
     def grandsire(stage: int) -> RowGenerator:

--- a/wheatley/row_generation/row_generator.py
+++ b/wheatley/row_generation/row_generator.py
@@ -4,7 +4,7 @@ import logging
 from abc import ABCMeta, abstractmethod
 
 from wheatley.aliases import Row, Places
-from wheatley.stroke import Stroke
+from wheatley.stroke import Stroke, HANDSTROKE
 from wheatley.row_generation.helpers import rounds
 
 
@@ -64,6 +64,11 @@ class RowGenerator(metaclass=ABCMeta):
     @abstractmethod
     def _gen_row(self, previous_row: Row, stroke: Stroke, index: int) -> Row:
         pass
+
+    def start_stroke(self) -> Stroke: # pylint: disable=no-self-use
+        """ Gets the stroke of the first row.  This defaults to HANDSTROKE, but should be overridden by
+        other RowGenerators if different start strokes are possible. """
+        return HANDSTROKE
 
     @abstractmethod
     def summary_string(self) -> str:

--- a/wheatley/stroke.py
+++ b/wheatley/stroke.py
@@ -21,6 +21,11 @@ class Stroke:
         """
         return not self._is_handstroke
 
+    @classmethod
+    def from_index(cls, index: int) -> 'Stroke':
+        """ Returns the stroke of the row that would exist at a given index. """
+        return cls(index % 2 == 0)
+
     def opposite(self) -> 'Stroke':
         """ Returns the opposite Stroke to the current one. """
         return Stroke(not self._is_handstroke)


### PR DESCRIPTION
This adds:
- `--start-index` for setting a start row index in methods (i.e. `--start-index 2` would be a snap start)
- Proper support for backstroke starts - both in CompLib compositions and in methods if the `--start-index` is odd

I hope you're not feeling too bombarded with PR emails :sweat_smile:.