### PR TITLE
Restrict socketio version.

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,6 +5,7 @@
 - Change place notation parsing to comply with CompLib and the XML specification.
 - Allow Wheatley to ring with any (positive) number of cover bells.
 - Add full static typing, and fix some `None`-related bugs.
+- Prevent installing the wrong version of socketio to work with RingingRoom
 
 # 0.5.2
 - Bump numpy version to exactly `1.19.3` on Windows to fix

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@ mypy==0.790
 mypy-extensions==0.4.3
 pylint==2.6.0
 pytest==5.4.3
-python-engineio==3.13.0
-python-socketio==4.6.0
+python-engineio==3.14.2
+python-socketio==4.6.1
 requests==2.24.0
 six==1.15.0
 urllib3==1.25.9

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ setuptools.setup(
         'numpy<=1.19.3; platform_system == "Windows"',
         'numpy; platform_system != "Windows"',
         "requests",
-        "python-socketio",
+        "python-socketio<5",
+        "python-engineio<4",
         "websocket-client"
     ],
     package_data={"wheatley": ["version.txt"]},


### PR DESCRIPTION
Python-socketio v5 is a major protocol jump that would need to be made at the same time as RingingRoom

Fixes #132 