### PR TITLE
Friendlier handling of ctrl-C

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,12 +7,14 @@
 - Add proper support for backstroke starts (with 3 rows of rounds for `--up-down-in`).
 - Add `--start-index` to specify how many rows into a lead of a method Wheatley should start.
 - Add `-v`/`--verbose` and `-q`/`--quiet` to change how much stuff Wheatley prints.
-- Print summary string of what Wheatley is going to ring before every touch.
+- Print summary string of what Wheatley is going to ring before every touch, as well as how to stop
+  Wheatley (i.e. using `<ctrl-C>`).
 - Tell users when Wheatley is waiting for `Look To`.
 - Make the error messages friendlier.
   - Moved some overly verbose `INFO` messages into `DEBUG`.
   - Capped all numbers to 3 decimal places.
   - Made debug 'wait' logging slightly less verbose.
+  - Wheatley simply prints `Bye!` when interrupted with `<ctrl-C>`
 - Fix broken version string (`Wheatley vv0.6.0` will now be `Wheatley v0.6.0`)
 
 ## Technical changes
@@ -22,8 +24,8 @@
 - Un-jankify error message for inputting an incorrect method title.
 - Change place notation parsing to comply with CompLib and the XML specification.
 - Add full static typing, and fix some `None`-related bugs.
-- Reimplement the Ringing Room integration code, and fix buggy expansion of PN when running on the
-  server.
+- Reimplement the Ringing Room integration code, and fix buggy expansion of place notation when
+  running on the server.
 
 
 

--- a/wheatley/bot.py
+++ b/wheatley/bot.py
@@ -78,8 +78,9 @@ class Bot:
 
         self.logger = logging.getLogger(self.logger_name)
 
-        # Log what we're going to ring
+        # Log what we're going to ring, and how to stop Wheatley
         self.logger.info(f"Wheatley will ring {self.row_generator.summary_string()}")
+        self.logger.info(f"Press `Control-C` to stop Wheatley ringing, e.g. to change method.")
 
     # Convenient properties that are frequently used
     @property

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -427,11 +427,14 @@ def console_main(override_args: Optional[List[str]], stop_on_join_tower: bool) -
     bot = Bot(tower, row_generator, args.use_up_down_in or args.handbell_style,
               args.stop_at_rounds or args.handbell_style, rhythm, user_name=args.name)
 
-    with tower:
-        tower.wait_loaded()
-
-        if not stop_on_join_tower:
-            bot.main_loop()
+    # Catch keyboard interrupts and just print 'Bye!' instead a load of guff
+    try:
+        with tower:
+            tower.wait_loaded()
+            if not stop_on_join_tower:
+                bot.main_loop()
+    except KeyboardInterrupt:
+        print("Bye!")
 
 def main(override_args: Optional[List[str]]=None, stop_on_join_tower: bool=False) -> None:
     """


### PR DESCRIPTION
A small but IMO much-needed quality of life improvement: Wheatley now simply says `Bye!` after `ctrl-C`, and also reminds the user to use `ctrl-C` to stop Wheatley running.