### PR TITLE
Allow passing CompLib URLs to `--comp`/`-c`

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -2,8 +2,8 @@
 
 ## User-facing changes
 
-- Add support for loading private CompLib urls from 'share' links using `--complib-share-link
-  <link>`.
+- Load comps (including private ones) from CompLib URLs with `--comp <url>` or `-c <url>`.  Using
+  CompLib IDs directly also works.
 - Wheatley now calls CompLib compositions (use `--no-calls` to suppress this)
 - Add proper support for backstroke starts (with 3 rows of rounds for `--up-down-in`).
 - Add `--start-index` to specify how many rows into a lead of a method Wheatley should start.

--- a/tests/row_generation/test_ComplibCompositionRowGenerator.py
+++ b/tests/row_generation/test_ComplibCompositionRowGenerator.py
@@ -18,7 +18,7 @@ class CompLibGeneratorTests(TestCase):
             )
         ]:
             with self.subTest(url=url, expected_title=expected_title):
-                self.assertEqual(ComplibCompositionGenerator.from_url(url).comp_title, expected_title)
+                self.assertEqual(ComplibCompositionGenerator.from_arg(url).comp_title, expected_title)
 
 
 if __name__ == '__main__':

--- a/wheatley/bot.py
+++ b/wheatley/bot.py
@@ -91,7 +91,7 @@ class Bot:
 
         # Log what we're going to ring, and how to stop Wheatley
         self.logger.info(f"Wheatley will ring {self.row_generator.summary_string()}")
-        self.logger.info(f"Press `Control-C` to stop Wheatley ringing, e.g. to change method.")
+        self.logger.info("Press `Control-C` to stop Wheatley ringing, e.g. to change method.")
 
     # Convenient properties that are frequently used
     @property

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -28,19 +28,14 @@ from wheatley.row_generation.place_holder_generator import PlaceHolderGenerator
 
 def create_row_generator(args: argparse.Namespace) -> RowGenerator:
     """ Generates a row generator according to the given CLI arguments. """
-    if "complib_share_link" in args and args.complib_share_link is not None:
+    if "comp" in args and args.comp is not None:
         try:
-            row_gen = ComplibCompositionGenerator.from_url(args.complib_share_link)
-        except (PrivateCompError, InvalidCompError) as e:
-            sys.exit(f"Bad value for '--comp': {e}")
-    elif "comp" in args and args.comp is not None:
-        try:
-            row_gen = ComplibCompositionGenerator(args.comp)
+            return ComplibCompositionGenerator.from_arg(args.comp)
         except (PrivateCompError, InvalidCompError) as e:
             sys.exit(f"Bad value for '--comp': {e}")
     elif "method" in args:
         try:
-            row_gen = generator_from_special_title(args.method) or \
+            return generator_from_special_title(args.method) or \
                       MethodPlaceNotationGenerator(
                           args.method,
                           parse_call(args.bob),
@@ -50,10 +45,7 @@ def create_row_generator(args: argparse.Namespace) -> RowGenerator:
         except MethodNotFoundError as e:
             sys.exit(f"Bad value for '--method': {e}")
     else:
-        assert False, \
-            "This shouldn't be possible because one of --method and --comp should always be defined"
-
-    return row_gen
+        assert False, "This shouldn't be possible because one of --method and --comp should always be defined"
 
 
 def create_rhythm(peal_speed: int, inertia: float, max_bells_in_dataset: int, handstroke_gap: float,
@@ -262,15 +254,8 @@ def console_main(override_args: Optional[List[str]], stop_on_join_tower: bool) -
     comp_method_group = row_gen_group.add_mutually_exclusive_group(required=True)
     comp_method_group.add_argument(
         "-c", "--comp",
-        type=int,
-        help="The ID of the complib composition you want to ring"
-    )
-    comp_method_group.add_argument(
-        "--complib-share-link",
         type=str,
-        help="The link from the 'share' button of the private complib composition you want to ring.  For \
-              example, \
-              https://complib.org/composition/73905?accessKey=67622abc16397c0e7df32d5f98e3b206bef980c6."
+        help="The ID or URL of the complib composition you want to ring"
     )
     comp_method_group.add_argument(
         "-m", "--method",

--- a/wheatley/parsing.py
+++ b/wheatley/parsing.py
@@ -219,7 +219,7 @@ def json_to_row_generator(json: JSON, logger: logging.Logger) -> RowGenerator:
             raise_error('url', "'url' is not defined", e)
 
         try:
-            row_gen = ComplibCompositionGenerator.from_url(comp_url)
+            row_gen = ComplibCompositionGenerator.from_arg(comp_url)
         except PrivateCompError as e:
             raise_error('complib request', "Comp id '{comp_url}' is private", e)
         except InvalidCompError as e:


### PR DESCRIPTION
Added code to parse both URLs and IDs, so that the `-c` option can accept URLs to access private links as well as IDs for terseness.