### PR TITLE
Make WaitForUser not wait if a user swaps bells assigned to them

### DIFF
--- a/wheatley/bot.py
+++ b/wheatley/bot.py
@@ -262,6 +262,7 @@ class Bot:
         if self._user_assigned_bell(bell):
             self._rhythm.expect_bell(
                 bell,
+                self._tower.get_assigned_user_name(bell),
                 self._row_number,
                 index,
                 self.stroke

--- a/wheatley/rhythm/abstract_rhythm.py
+++ b/wheatley/rhythm/abstract_rhythm.py
@@ -28,7 +28,7 @@ class Rhythm(metaclass=ABCMeta):
         """ Sleeps the thread until a given Bell should have rung. """
 
     @abstractmethod
-    def expect_bell(self, expected_bell: Bell, row_number: int, place: int, expected_stroke: Stroke) -> None:
+    def expect_bell(self, expected_bell: Bell, user: str, row_number: int, place: int, expected_stroke: Stroke) -> None:
         """
         Indicates that a given Bell is expected to be rung at a given row, place and stroke.
         Used by the rhythm so that when that bell is rung later, it can tell where that bell
@@ -55,6 +55,6 @@ class Rhythm(metaclass=ABCMeta):
                         number_of_user_controlled_bells: int) -> None:
         """ Allow the Rhythm object to initialise itself when 'Look to' is called. """
 
-    def sleep(self, seconds: float) -> None: #  pylint: disable=no-self-use
+    def sleep(self, seconds: float) -> None:  # pylint: disable=no-self-use
         """ Sleeps for given number of seconds. Allows mocking in tests"""
         time.sleep(seconds)

--- a/wheatley/rhythm/regression.py
+++ b/wheatley/rhythm/regression.py
@@ -185,7 +185,7 @@ class RegressionRhythm(Rhythm):
 
         self._should_return_to_mainloop = False
 
-    def expect_bell(self, expected_bell: Bell, row_number: int, place: int, expected_stroke: Stroke) -> None:
+    def expect_bell(self, expected_bell: Bell, user: str, row_number: int, place: int, expected_stroke: Stroke) -> None:
         """
         Indicates that a given Bell is expected to be rung at a given row, place and stroke.
         Used by the rhythm so that when that bell is rung later, it can tell where that bell

--- a/wheatley/tower.py
+++ b/wheatley/tower.py
@@ -83,6 +83,13 @@ class RingingRoomTower:
             self.logger.error(e)
             return False
 
+    def get_assigned_user_name(self, bell: Bell) -> Optional[str]:
+        """ Returns the user name assigned to a bell """
+        assigned_user_id = self._assigned_users.get(bell, None)
+        if assigned_user_id is None:
+            return None
+        return self.user_name_from_id(assigned_user_id)
+
     def is_bell_assigned_to(self, bell: Bell, user_name: Optional[str]) -> bool:
         """ Returns true if a given bell is assigned to the given user name. """
         try:


### PR DESCRIPTION
This only deals with waiting for a user to have rung the right number of bells in any order. 
In terms of regression rhythm if someone's just swapped then 1 bell's early and the other late, so hopefully averages out somewhat.

Needs more testing, but I can ring a course of Plain Bob Minor with my bells swapped over with this.