### PR TITLE
Adding some basic instructions for google colab

### DIFF
--- a/SIMPLE_ONLINE.md
+++ b/SIMPLE_ONLINE.md
@@ -1,0 +1,26 @@
+# Simple setup for online use
+
+This is a short guide for running Wheatley online using google colab.
+
+## Google Colab
+
+To use this method you will need a google account.
+
+* Go to https://colab.research.google.com/ and log in
+* Go to File > New Notebook
+* In the first text box enter:
+```
+!pip install --upgrade wheatley
+```
+* Click "+ Code"
+* In the second text box enter the wheatley command in the form:
+```bash
+!wheatley [ID NUMBER] --peal-speed 3h15 --method "Plain Bob Major"
+```
+
+## Starting Wheatley
+
+To start the process running go to "Runtime > Run all" (or ctrl + f9)
+
+To stop wheatley click the stop icon (black square) on the left of the second code block.
+To restart click the play icon on the left of the second code block


### PR DESCRIPTION
Adding a markdown instruction file for google colab.

A good free place for people with google accounts who don't want to install python locally.
I tested it out and connection speed etc seems fine.