### PR TITLE
Parallel main matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,13 +13,46 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: [3.6, 3.9]
 
     steps:
       - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # Cache python site-packages on Windows (e.g. C:\hostedtoolcache\windows\Python\3.7.9\x64)
+      # This saves installed pip packages, so hash on requirements.txt as well  
+      - name: Cache python site-packages
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}\lib\site-packages
+          key: ${{ env.pythonLocation }}\lib\site-packages-${{ matrix.os }}-${{ hashFiles('requirements.txt') }}
+        if: ${{ matrix.os == 'windows-latest' }}
+      
+      # Just cache pip wheels on Linux / Mac
+      - name: Get pip cache dir
+        id: pip-cache
+        run: echo "::set-output name=dir::$(pip cache dir)"
+        if: ${{ matrix.os != 'windows-latest' }}
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ matrix.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+        if: ${{ matrix.os != 'windows-latest' }}
+    
       - name: Install dependencies
         run: |
           pip3 install setuptools
+          pip3 install wheel
           pip3 install -r requirements.txt
       - name: Run linter
         run: python3 run-checks.py --lint

--- a/run-checks.py
+++ b/run-checks.py
@@ -61,9 +61,13 @@ class Check:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if exc_type is None:
-            print(f"\u2705 {self.title} passed")
+            message = f"\u2705 {self.title} passed"
         else:
-            print(f"\u274c {self.title} failed")
+            message = f"\u274c {self.title} failed"
+        try:
+            print(message)
+        except UnicodeEncodeError:
+            print(message[2:])
 
 
 # Ignore first argument (this file name)
@@ -117,9 +121,3 @@ if run_all or parsed_args.type_check:
 print("""
 ====== Success ======
     """)
-
-
-
-
-
-


### PR DESCRIPTION
 Run main build multiple OS and Python versions

    - 3.6 and 3.9 as min/max supported version.
    - Windows, macOS and Linux
    - Cache python site-packages on Windows for install speed
    - On Linux/macOS just cache pip wheels