### PR TITLE
Improve changelog

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -4,9 +4,9 @@
 
 - (#181) Make the behaviour of `That's All` more intuitive (i.e. calling `That's All` during rounds
   will no longer cause Wheatley to ring one erroneous row of method).
-- (#159, first contribution) Start ringing at a custom row (using `--start-row <row>`).  This
+- (#159, thanks @chrisjfield) Start ringing at a custom row (using `--start-row <row>`).  This
   doesn't work for CompLib compositions.
-- (#169, first contribution) Ring arbitrary place notation on a given stage (using
+- (#169, thanks @aajshaw) Ring arbitrary place notation on a given stage (using
   `--place-notation <stage>:<place-notation>`).  `--bob` and `--single` still apply.
 - (#184) `--stop-at-rounds` now leaves the bells set at hand even if the touch finishes on a
   handstroke.
@@ -16,15 +16,13 @@
 
 ## Internal Improvements
 
-- (#190, first contribution) Speed up doctests
+- (#197) Use the black autoformatter to keep a consistent code style.
+- (#190, thanks @jrs1061) Speed up doctests
 - (#165, #172, #186) Improve developer experience on Windows
-- (#170, first contribution) Fix typo in comment
+- (#170, thanks @jamesscottbrown) Fix typo in comment
 - (#174, #195) Add then remove autorebase workflow
 
 
-
-## Technical Changes
-- (#197) Use the black autoformatter to keep a consistent code style.
 
 # 0.6.0
 

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -2,13 +2,26 @@
 
 ## User-facing changes
 
-- Make the behaviour of `That's All` more intuitive (i.e. calling `That's All` during rounds will
-  no longer cause Wheatley to ring one erroneous row of method).
-- Start ringing at a custom row (using `--start-row <row>`).  This doesn't work for CompLib
-  compositions.
-- Ring arbitrary place notation on a given stage (using
+- (#181) Make the behaviour of `That's All` more intuitive (i.e. calling `That's All` during rounds
+  will no longer cause Wheatley to ring one erroneous row of method).
+- (#159, first contribution) Start ringing at a custom row (using `--start-row <row>`).  This
+  doesn't work for CompLib compositions.
+- (#169, first contribution) Ring arbitrary place notation on a given stage (using
   `--place-notation <stage>:<place-notation>`).  `--bob` and `--single` still apply.
-- `--stop-at-rounds` now leaves the bells set at hand even if the touch finishes on a handstroke.
+- (#184) `--stop-at-rounds` now leaves the bells set at hand even if the touch finishes on a
+  handstroke.
+- (#179) Overhaul the `README.md`
+- (#182) Ignore the `username` param when users leave (this is deprecated and will be removed in
+  later versions of RR)
+
+## Internal Improvements
+
+- (#190, first contribution) Speed up doctests
+- (#165, #172, #186) Improve developer experience on Windows
+- (#170, first contribution) Fix typo in comment
+- (#174, #195) Add then remove autorebase workflow
+
+
 
 ## Technical Changes
 - (#197) Use the black autoformatter to keep a consistent code style.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ scope of potential practices, designed to be a **'ninja helper with no ego'**.
 If you just want to use Wheatley for normal ringing without caring about how it works, then check
 out how to use Wheatley directly [inside Ringing Room](https://ringingroom.com/help#wheatley) - no
 installation required, just a flick of a switch.  If you want more control than the Ringing Room
-interface proveds or are interested in how Wheatley works, then this is the place to go.  This
+interface provides or are interested in how Wheatley works, then this is the place to go.  This
 repository contains Wheatley's source code, and documentation of the 'classic' command line version.
 
 ## Contributing


### PR DESCRIPTION
Add a few missing PRs to the changelog, and also add PR numbers and first contributions.  We could potentially make a CI action to enforce that every incoming PR changes `CHANGE_LOG.md`, but this is probably not necessary.