### PR TITLE
Add more examples of compositions

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,33 @@ python3 -m wheatley [ID NUMBER] --method "Plain Bob Major"
     wheatley [ID NUMBER] --url otherwebsite.com --method [METHOD TITLE]
     ```
 
-*   Ring rows taken from a (public) composition from [complib.org](http://complib.org/), in this
+*   Ring rows and make calls taken from a composition from [complib.org](http://complib.org/), in this
     case https://complib.org/composition/65034:
     ```bash
     wheatley [ID NUMBER] --comp 65034
+    ```
+*   Ring rows but don't send the calls to Ringing Room taken from a composition from [complib.org](http://complib.org/), in this
+    case https://complib.org/composition/65034:
+    ```bash
+    wheatley [ID NUMBER] --comp 65034 --no-calls
+    ```
+
+*   Ring compositions with **substituted methods** by copying the id and query string or full url from [complib.org](http://complib.org/)):
+    ```bash
+     wheatley [ID NUMBER] --comp 68549?substitutedmethodid=28000
+     # or 
+     wheatley [ID NUMBER] --comp https://complib.org/composition/68549?substitutedmethodid=28000
+    ```
+*   Ring **private** compositions by copying the share link from [complib.org](http://complib.org/):
+    ```bash
+     wheatley [ID NUMBER] --comp 51155?accessKey=9e1fcd2b11435552cf236be93c7ff73058870995
+     # or
+     wheatley [ID NUMBER] --comp https://complib.org/composition/51155?accessKey=9e1fcd2b11435552cf236be93c7ff73058870995
+    ```
+* Combine method substitution and private composition
+    <!--- doctest-ignore -->
+    ```bash
+     wheatley [ID NUMBER] --comp 51155?substitutedmethodid=27600&accessKey=9e1fcd2b11435552cf236be93c7ff73058870995
     ```
 
 *   Ring rows specified by place notation, in this case Plain Bob Minor:
@@ -139,4 +162,8 @@ python3 -m wheatley [ID NUMBER] --method "Plain Bob Major"
     wheatley [ID NUMBER] --method [METHOD TITLE] --inertia 1.0
     # or
     wheatley [ID NUMBER] --method [METHOD TITLE] -I 1.0
+    ```
+*   Start from a different row
+    ``` bash
+    wheatley [ID NUMBER] --method [METHOD TITLE] --start-row 13572468
     ```

--- a/tests/row_generation/test_ComplibCompositionRowGenerator.py
+++ b/tests/row_generation/test_ComplibCompositionRowGenerator.py
@@ -16,6 +16,11 @@ class CompLibGeneratorTests(TestCase):
                 "https://complib.org/composition/70383?accessKey=cf75d5e0d213d4d3ea38f58f5bfdfd8e86b99ccf",
                 "56 3-Spliced Bob Royal",
             ),
+            (
+                "https://complib.org/composition/51155?substitutedmethodid=27600"
+                + "&accessKey=9e1fcd2b11435552cf236be93c7ff73058870995",
+                "720 Moss Treble Place Minor",
+            ),
         ]:
             with self.subTest(url=url, expected_title=expected_title):
                 self.assertEqual(ComplibCompositionGenerator.from_arg(url).comp_title, expected_title)

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -292,7 +292,11 @@ def console_main(override_args: Optional[List[str]], stop_on_join_tower: bool) -
     # a CompLib comp or a place notation
     comp_method_place_group = row_gen_group.add_mutually_exclusive_group(required=True)
     comp_method_place_group.add_argument(
-        "-c", "--comp", type=str, help="The ID or URL of the complib composition you want to ring"
+        "-c",
+        "--comp",
+        type=str,
+        help="The ID or URL of the complib composition you want to ring. \
+        This can include a substituted method or access key query string",
     )
     comp_method_place_group.add_argument(
         "-m", "--method", type=str, help="The title of the method you want to ring"


### PR DESCRIPTION
- Add more examples to ReadMe
  - Compositions with substituted method & private compositions
  - Custom start row example
  - Connection test for complib with access key and substituted method

- Restrict parallel doctests
Prevent memory issue starting processes for all in parallel.