### PR TITLE
Rename formatting workflow from `lint` to `format`

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  lint:
+  format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The current name is confusing, because the linter is run in `build`.  I'll update the required checks so we aren't in the same situation as with the rogue `build` check after #185.