### PR TITLE
Add spacing in `--help` for Grandsire calls

### DIFF
--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -315,9 +315,9 @@ def console_main(override_args: Optional[List[str]], stop_on_join_tower: bool) -
         default="14",
         help='An override for what place notation(s) should be made when a `Bob` is called in \
               Ringing Room.  These will by default happen at the lead end.  Examples: "16" or \
-              "0:16" => 6ths place lead end bob.  "-1:3" or "-1:3.1" => a Grandsire Bob.  "20: 70" \
+              "0: 16" => 6ths place lead end bob.  "-1: 3" or "-1: 3.1" => a Grandsire Bob.  "20: 70" \
               => a 70 bob taking effect 20 changes into a lead (the Half Lead for Surprise Royal). \
-              "20:7/0:4" => a 70 bob 20 changes into a lead and a 14 bob at the lead end. \
+              "20: 7/0: 4" => a 70 bob 20 changes into a lead and a 14 bob at the lead end. \
               "3: 5/9: 5" => bobs in Stedman Triples.  Defaults to "14".',
     )
     row_gen_group.add_argument(
@@ -326,7 +326,7 @@ def console_main(override_args: Optional[List[str]], stop_on_join_tower: bool) -
         default="1234",
         help='An override for what place notation(s) should be made when a `Single` is called in \
               Ringing Room.  These will by default happen at the lead end.  Examples: "1678" or \
-              "0:1678" => 6ths place lead end single.  "-1:3.123" => a Grandsire Single. \
+              "0: 1678" => 6ths place lead end single.  "-1: 3.123" => a Grandsire Single. \
               "20: 7890" => a 7890 single taking effect 20 changes into a lead (the Half Lead for \
               Surprise Royal). "3: 567/9: 567" => singles in Stedman Triples.  Defaults to "1234".',
     )


### PR DESCRIPTION
Spacing is required because Python's arg parsing library treats `"-1:3.123"` in e.g. `wheatley 123456789 --single "-1:3.123"` as a set of short arguments (same as `-.:123`).  However, inserting whitespace like in `"-1: 3.123"` means that `argparse` can't treat it as a set of short options.

An open question is whether it's worth actually explaining the problem in `--help` but I think the help is long enough already and in most cases this is simply unnecessary detail.  It should probably be documented somewhere other than a commit message, though, but I'm not sure of the best place.  @centreboard, thoughts?