### PR TITLE
Bump numpy to 1.23.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 certifi==2020.4.5.2
 chardet==3.0.4
 idna==2.9
-numpy==1.19.3; platform_system == "Windows"
-numpy==1.18.5; platform_system != "Windows"
+numpy==1.23.4; python_version >= '3.8'
+numpy==1.19.5; python_version < '3.8'
 mypy==0.790
 mypy-extensions==0.4.3
 pylint==2.8.3

--- a/tests/row_generation/test_ComplibCompositionRowGenerator.py
+++ b/tests/row_generation/test_ComplibCompositionRowGenerator.py
@@ -8,8 +8,8 @@ from wheatley.row_generation import ComplibCompositionGenerator
 class CompLibGeneratorTests(TestCase):
     def test_comp_fetching(self):
         for (url, expected_title) in [
-            ("complib.org/composition/62355", "5040 Plain Bob Major Op. Cyclic #1 by Ben White-Horne"),
-            ("www.complib.org/composition/62355", "5040 Plain Bob Major Op. Cyclic #1 by Ben White-Horne"),
+            ("complib.org/composition/62355", "5040 Plain Bob Major by Ben White-Horne"),
+            ("www.complib.org/composition/62355", "5040 Plain Bob Major by Ben White-Horne"),
             ("https://www.complib.org/composition/71994", "110 2-Spliced Major"),
             ("https://complib.org/composition/71994", "110 2-Spliced Major"),
             (

--- a/wheatley/rhythm/regression.py
+++ b/wheatley/rhythm/regression.py
@@ -273,7 +273,7 @@ class RegressionRhythm(Rhythm):
 
             # Calculate the weight (which will be 1 if it is either of the first two bells to be
             # rung to not skew the data from the start)
-            weight = math.exp(-(diff ** 2))
+            weight = math.exp(-(diff**2))
             if len(self.data_set) <= 1:
                 weight = 1
 

--- a/wheatley/rhythm/regression.py
+++ b/wheatley/rhythm/regression.py
@@ -40,9 +40,9 @@ def calculate_regression(data_set: List[Tuple[float, float, float]]) -> Tuple[fl
 
     num_datapoints = len(weights)
 
-    x = numpy.array([[1, b] for b in blow_times])
-    w = numpy.array([fill(i, w, num_datapoints) for (i, w) in enumerate(weights)])
-    y = numpy.array([[x] for x in real_times])
+    x: numpy.ndarray = numpy.array([[1, b] for b in blow_times])
+    w: numpy.ndarray = numpy.array([fill(i, w, num_datapoints) for (i, w) in enumerate(weights)])
+    y: numpy.ndarray = numpy.array([[x] for x in real_times])
 
     # Calculate (X^T * W * X)^-1 * (X^T * W * y)
     beta = numpy.linalg.inv(x.transpose().dot(w).dot(x)).dot(x.transpose()).dot(w).dot(y)


### PR DESCRIPTION
Previously, NumPy was pinned to an old version on Windows to avoid a bug in a Windows update.  However, that bug has now been fixed and that old NumPy version is now incompatible with the version of Python now in the Windows store (Python 3.10).  The old version also has known security vulnerabilities, giving one final reason to update.

[NumPy 1.20](https://numpy.org/devdocs/release/1.20.0-notes.html) dropped support for Python 3.6, and [NumPy 1.22](https://numpy.org/devdocs/release/1.22.0-notes.html) dropped support for Python 3.7.  So, we use NumPy 1.19.5 for Python < 3.8 and latest NumPy for everything else.