### PR TITLE
Fix `next_row_generator` race condition

### DIFF
--- a/wheatley/bot.py
+++ b/wheatley/bot.py
@@ -271,8 +271,9 @@ class Bot:
         )
 
         # Move to the next row generator if it's defined
-        self.row_generator = self.next_row_generator or self.row_generator
-        self.next_row_generator = None
+        with self.next_row_generator_lock:
+            self.row_generator = self.next_row_generator or self.row_generator
+            self.next_row_generator = None
 
         # Clear all the flags and counters
         self._should_stand = False


### PR DESCRIPTION
This fixes a bug where `Bot.next_row_generator_lock` was not held when loading the `Bot.next_row_generator` for a new touch.  This meant that, if the `next_row_generator` were to take more than a few milliseconds to load, the main thread wouldn't wait for the loading to finish and would blindly read the old value of `Bot.next_row_generator`.

Downloading a peal-length composition from CompLib takes ~300ms, which is enough to consistently trigger this race condition.  Therefore, this fix is required for compositions to work in Ringing Room.