### PR TITLE
Allow Ringing Room to set the `--call-comps` flag

### DIFF
--- a/wheatley/bot.py
+++ b/wheatley/bot.py
@@ -155,6 +155,12 @@ class Bot:
                 self.logger.info(f"Setting 'stop_at_rounds' to {value}")
             except ValueError:
                 log_invalid_key(f"{value} cannot be converted into a bool")
+        elif key == "call_composition":
+            try:
+                self._call_comps = to_bool(value)
+                self.logger.info(f"Setting 'call_composition' to {value}")
+            except ValueError:
+                log_invalid_key(f"{value} cannot be converted into a bool")
         else:
             self._rhythm.change_setting(key, value, time.time())
 


### PR DESCRIPTION
Needed for the Ringing Room composition integration, since Bryn & Leland want users to be able to silence Wheatley's calls from within Ringing Room.

The Ringing-Room side of this change will be added and documented in lelandpaul/ringingroom#266 (once I push the new changes).