### PR TITLE
Bump versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 black==22.8.0
-certifi==2022.12.7
-chardet==5.0.0
+certifi==2023.5.7
+chardet==5.1.0
 idna==3.4
 numpy==1.24.2; python_version >= '3.8'
 numpy==1.19.5; python_version < '3.8'
@@ -12,12 +12,12 @@ pylint==2.16.2; python_version >= '3.8'
 pylint==2.13.9; python_version < '3.8'
 pytest==7.2.1; python_version >= '3.8'
 pytest==7.0.1; python_version < '3.8'
-python-engineio==3.14.2
-python-socketio==4.6.1
-requests==2.27.1
+python-engineio==4.5.1
+python-socketio==5.8.0
+requests==2.31.0
 six==1.16.0
 types-requests==2.28.11.14
 types-urllib3==1.26.25.7
-urllib3==1.26.14
-websocket-client==1.5.1; python_version >= '3.8'
+urllib3==2.0.3
+websocket-client==1.6.1; python_version >= '3.8'
 websocket-client==1.3.1; python_version < '3.8'


### PR DESCRIPTION
I'm working on a variety of version-bumps for Ringing Room. This will require Wheatley to use the latest socketio versions.

This has been tested against a local build of Ringing Room; it will fail against the production RR due to backwards-compatibility issues in socketio.